### PR TITLE
Merge stability flags

### DIFF
--- a/tests/phpunit/fixtures/testUpdateStabilityFlags/composer.json
+++ b/tests/phpunit/fixtures/testUpdateStabilityFlags/composer.json
@@ -1,0 +1,7 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "include": "composer.local.json"
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testUpdateStabilityFlags/composer.local.json
+++ b/tests/phpunit/fixtures/testUpdateStabilityFlags/composer.local.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "test/foo": "dev-master",
+        "test/bar": "~1.0@beta",
+        "test/baz": "0.1@alpha",
+        "test/xyzzy": "1.0.0-rc1"
+    }
+}


### PR DESCRIPTION
Extract stability flags from version strings used to declare requirements and merge them into the root package.

Closes #9
