### PR TITLE
Add support for packagist: false

### DIFF
--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -327,6 +327,9 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
         $newRepos = array();
 
         foreach ($repositories as $repoJson) {
+            if (! isset($repoJson['type'])) {
+                continue;
+            }
             $this->debug("Adding {$repoJson['type']} repository");
             $repo = $repoManager->createRepository(
                 $repoJson['type'],


### PR DESCRIPTION
When using private satis, composer gives support for {packagist: false} in root schema repositories:

```javascript
{
    "repositories": [
        {
            "packagist": false
        }
    ]
}
```

This patch serves the purpose to not make the assumption of the index *type* in all *repositories* items.
