### PR TITLE
Fix InstallerEvent constructor args in tests

### DIFF
--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -359,6 +359,7 @@ class MergePluginTest extends \Prophecy\PhpUnit\ProphecyTestCase
             InstallerEvents::PRE_DEPENDENCIES_SOLVING,
             $this->composer->reveal(),
             $this->io->reveal(),
+            true, //dev mode
             $this->prophesize('Composer\DependencyResolver\PolicyInterface')->reveal(),
             $this->prophesize('Composer\DependencyResolver\Pool')->reveal(),
             $this->prophesize('Composer\Repository\CompositeRepository')->reveal(),


### PR DESCRIPTION
Fix #22 by adding the newly required `$devMode` parameter to the
`Composer\Installer\InstallerEvent` constructors used in testing.