### PR TITLE
Remove deprecated PHPUnitn strict option

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit colors="true" strict="true">
+<phpunit colors="true">
     <testsuites>
         <testsuite name="Tests">
             <directory>./tests/phpunit</directory>


### PR DESCRIPTION
Currently getting a deprecation warning when I run the tests