### PR TITLE
Merge in the autoload sections of merged packages

### DIFF
--- a/tests/phpunit/fixtures/testMergedAutoload/composer.json
+++ b/tests/phpunit/fixtures/testMergedAutoload/composer.json
@@ -1,0 +1,12 @@
+{
+	"autoload": {
+		"psr-4": {
+			"Kittens\\": "everywhere/"
+		}
+	},
+	"extra": {
+		"merge-plugin": {
+			"include": "extensions/*/composer.json"
+		}
+	}
+}

--- a/tests/phpunit/fixtures/testMergedAutoload/extensions/Foo/composer.json
+++ b/tests/phpunit/fixtures/testMergedAutoload/extensions/Foo/composer.json
@@ -1,0 +1,19 @@
+{
+	"autoload": {
+		"psr-4": {
+			"Kittens\\": [ "a/", "b/" ],
+			"Cats\\": "src/"
+		},
+		"psr-0": {
+			"UniqueGlobalClass": "",
+			"": "fallback/"
+		},
+		"files" : [
+			"SemanticMediaWiki.php"
+		],
+		"classmap": [
+			"SemanticMediaWiki.hooks.php",
+			"includes/"
+		]
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/wikimedia/composer-merge-plugin/issues/18

Please note that I have only tested this automatically. It's possible I misunderstood what should happen and thus wrote an incorrect test. Manual testing on a real install before merging is advised.