### PR TITLE
Fix issues reported by Scrutinizer tests

### DIFF
--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -203,7 +203,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
         }
         $this->debug("Loading <comment>{$path}</comment>...");
         $json = $this->readPackageJson($path);
-        $package = $this->loader->load($json);
+        $package = $this->jsonToPackage($json);
 
         $this->mergeRequires($root, $package);
         $this->mergeDevRequires($root, $package);
@@ -441,6 +441,21 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             );
         }
         return $root;
+    }
+
+    /**
+     * @return CompletePackage
+     */
+    protected function jsonToPackage($json)
+    {
+        $package = $this->loader->load($json);
+        if (!$package instanceof CompletePackage) {
+            throw new UnexpectedValueException(
+                'Expected instance of CompletePackage, got ' .
+                get_class($package)
+            );
+        }
+        return $package;
     }
 
     /**

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -435,11 +435,13 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     protected function getRootPackage()
     {
         $root = $this->composer->getPackage();
+        // @codeCoverageIgnoreStart
         if (!$root instanceof RootPackage) {
             throw new UnexpectedValueException(
                 'Expected instance of RootPackage, got ' . get_class($root)
             );
         }
+        // @codeCoverageIgnoreEnd
         return $root;
     }
 
@@ -449,12 +451,14 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     protected function jsonToPackage($json)
     {
         $package = $this->loader->load($json);
+        // @codeCoverageIgnoreStart
         if (!$package instanceof CompletePackage) {
             throw new UnexpectedValueException(
                 'Expected instance of CompletePackage, got ' .
                 get_class($package)
             );
         }
+        // @codeCoverageIgnoreEnd
         return $package;
     }
 
@@ -468,6 +472,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
      */
     protected function debug($message)
     {
+        // @codeCoverageIgnoreStart
         if ($this->inputOutput->isVerbose()) {
             $message = "  <info>[merge]</info> {$message}";
 
@@ -478,6 +483,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
                 $this->inputOutput->write($message);
             }
         }
+        // @codeCoverageIgnoreEnd
     }
 }
 // vim:sw=4:ts=4:sts=4:et:

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -177,7 +177,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
      */
     protected function mergePackages(array $config)
     {
-        $root = $this->composer->getPackage();
+        $root = $this->getRootPackage();
         foreach (array_reduce(
             array_map('glob', $config['include']),
             'array_merge',

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -259,7 +259,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
         CompletePackage $package
     ) {
         $requires = $package->getRequires();
-        if (!$requires) {
+        if (empty($requires)) {
             return;
         }
 
@@ -281,7 +281,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
         CompletePackage $package
     ) {
         $requires = $package->getDevRequires();
-        if (!$requires) {
+        if (empty($requires)) {
             return;
         }
 
@@ -305,8 +305,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
         $path
     ) {
         $autoload = $package->getAutoload();
-
-        if (!$autoload) {
+        if (empty($autoload)) {
             return;
         }
 
@@ -413,7 +412,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
      */
     public function onDependencySolve(InstallerEvent $event)
     {
-        if (!$this->duplicateLinks) {
+        if (empty($this->duplicateLinks)) {
             return;
         }
 


### PR DESCRIPTION
* Use Composer\Package\RootPackage type hint
* Use empty() to check arrays
* Type hint ArrayLoader::load()
* Mark debugging code ignored for coverage reports