### PR TITLE
Add autoload-dev support

### DIFF
--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -251,6 +251,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
         $this->mergeRequires($root, $package);
         $this->mergeDevRequires($root, $package);
         $this->mergeAutoload($root, $package, $path);
+        $this->mergeDevAutoload($root, $package, $path);
 
         if (isset($json['repositories'])) {
             $this->addRepositories($json['repositories'], $root);
@@ -352,19 +353,53 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             return;
         }
 
-        $packagePath = substr($path, 0, strrpos($path, '/') + 1);
-
-        array_walk_recursive(
-            $autoload,
-            function(&$path) use ($packagePath) {
-                $path = $packagePath . $path;
-            }
-        );
+        $this->prependPath($path, $autoload);
 
         $root->setAutoload(array_merge_recursive(
             $root->getAutoload(),
             $autoload
         ));
+    }
+
+    /**
+     * @param RootPackage $root
+     * @param CompletePackage $package
+     * @param string $path
+     */
+    protected function mergeDevAutoload(
+        RootPackage $root,
+        CompletePackage $package,
+        $path
+    ) {
+        $autoload = $package->getDevAutoload();
+        if (empty($autoload)) {
+            return;
+        }
+
+        $this->prependPath($path, $autoload);
+
+        $root->setDevAutoload(array_merge_recursive(
+            $root->getDevAutoload(),
+            $autoload
+        ));
+    }
+
+    /**
+     * Prepend a path to a collection of paths.
+     *
+     * @param string $basePath
+     * @param array $paths
+     */
+    protected function prependPath($basePath, array &$paths)
+    {
+        $basePath = substr($basePath, 0, strrpos($basePath, '/') + 1);
+
+        array_walk_recursive(
+            $paths,
+            function (&$localPath) use ($basePath) {
+                $localPath = $basePath . $localPath;
+            }
+        );
     }
 
     /**

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -349,6 +349,7 @@ class MergePluginTest extends \Prophecy\PhpUnit\ProphecyTestCase
         $root = $this->rootFromJson("{$dir}/composer.json");
 
         $root->getAutoload()->shouldBeCalled();
+        $root->getDevAutoload()->shouldBeCalled();
         $root->getRequires()->shouldNotBeCalled();
         $root->setAutoload(Argument::type('array'))->will(
             function ($args) use ($that) {
@@ -364,6 +365,28 @@ class MergePluginTest extends \Prophecy\PhpUnit\ProphecyTestCase
                         ),
                         'files' => array( 'extensions/Foo/SemanticMediaWiki.php' ),
                         'classmap' => array( 'extensions/Foo/SemanticMediaWiki.hooks.php', 'extensions/Foo/includes/' ),
+                    ),
+                    $args[0]
+                );
+            }
+        );
+        $root->setDevAutoload(Argument::type('array'))->will(
+            function ($args) use ($that) {
+                $that->assertEquals(
+                    array(
+                        'psr-4' => array(
+                            'Dev\\Kittens\\' => array( 'everywhere/', 'extensions/Foo/a/', 'extensions/Foo/b/' ),
+                            'Dev\\Cats\\' => 'extensions/Foo/src/'
+                        ),
+                        'psr-0' => array(
+                            'DevUniqueGlobalClass' => 'extensions/Foo/',
+                            '' => 'extensions/Foo/dev/fallback/'
+                        ),
+                        'files' => array( 'extensions/Foo/DevSemanticMediaWiki.php' ),
+                        'classmap' => array(
+                            'extensions/Foo/DevSemanticMediaWiki.hooks.php',
+                            'extensions/Foo/dev/includes/',
+                        ),
                     ),
                     $args[0]
                 );
@@ -523,6 +546,7 @@ class MergePluginTest extends \Prophecy\PhpUnit\ProphecyTestCase
                 'suggest' => array(),
                 'extra' => array(),
                 'autoload' => array(),
+                'autoload-dev' => array(),
             ),
             $json
         );
@@ -534,6 +558,7 @@ class MergePluginTest extends \Prophecy\PhpUnit\ProphecyTestCase
         $root->getSuggests()->willReturn($data['suggest']);
         $root->getExtra()->willReturn($data['extra'])->shouldBeCalled();
         $root->getAutoload()->willReturn($data['autoload']);
+        $root->getDevAutoload()->willReturn($data['autoload-dev']);
 
         $root->getStabilityFlags()->willReturn(array());
         $root->setStabilityFlags(Argument::type('array'))->will(

--- a/tests/phpunit/fixtures/testMergedAutoload/composer.json
+++ b/tests/phpunit/fixtures/testMergedAutoload/composer.json
@@ -4,6 +4,11 @@
 			"Kittens\\": "everywhere/"
 		}
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"Dev\\Kittens\\": "everywhere/"
+		}
+	},
 	"extra": {
 		"merge-plugin": {
 			"include": "extensions/*/composer.json"

--- a/tests/phpunit/fixtures/testMergedAutoload/extensions/Foo/composer.json
+++ b/tests/phpunit/fixtures/testMergedAutoload/extensions/Foo/composer.json
@@ -15,5 +15,22 @@
 			"SemanticMediaWiki.hooks.php",
 			"includes/"
 		]
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Dev\\Kittens\\": [ "a/", "b/" ],
+			"Dev\\Cats\\": "src/"
+		},
+		"psr-0": {
+			"DevUniqueGlobalClass": "",
+			"": "dev/fallback/"
+		},
+		"files" : [
+			"DevSemanticMediaWiki.php"
+		],
+		"classmap": [
+			"DevSemanticMediaWiki.hooks.php",
+			"dev/includes/"
+		]
 	}
 }


### PR DESCRIPTION
Currently [`autoload-dev`](https://getcomposer.org/doc/04-schema.md#autoload-dev) blocks aren't merged (whereas `require-dev` are). This adds them in.