### PR TITLE
Add support for 'last defined package wins' conflict resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Usage
             "include": [
                 "composer.local.json",
                 "extensions/*/composer.json"
-            ]
+            ],
+            "recurse": false,
+            "replace": false
         }
     }
 }
@@ -36,13 +38,22 @@ The `include` key can specify either a single value or an array of values.
 Each value is treated as a glob() pattern identifying additional composer.json
 style configuration files to merge into the configuration for the current
 Composer execution. By default the merge plugin is recursive, if an included
-file also has a "merge-plugin" section it will also be processed. This 
-functionality can be disabled by setting `"recurse": false` inside the 
+file also has a "merge-plugin" section it will also be processed. This
+functionality can be disabled by setting `"recurse": false` inside the
 "merge-plugin" section.
 
 The "require", "require-dev", "repositories" and "suggest" sections of the
 found configuration files will be merged into the root package configuration
 as though they were directly included in the top-level composer.json file.
+
+By default, Composer's normal conflict resolution engine is used to determine
+which version of a package should be installed if multiple files specify the
+same package. A `"replace": true` setting can be provided inside the
+"merge-plugin" section to change to a "last version specified wins" conflict
+resolution strategy. In this mode, duplicate package declarations in merged
+files will overwrite the declarations made in earlier files. Files are loaded
+in the order specified in the `include` section with globbed files being
+loaded in alphabetical order.
 
 Running tests
 -------------

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -108,6 +108,16 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     protected $recurse = true;
 
     /**
+     * Whether to replace duplicate links.
+      *
+      * Normally, duplicate links are resolved using Composer's resolver.
+      * Setting this flag changes the behaviour to 'last definition wins'.
+     *
+     * @var bool $replace
+     */
+    protected $replace = false;
+
+    /**
      * Files that have already been processed
      *
      * @var string[] $loadedFiles
@@ -173,6 +183,9 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
         $config = $this->readConfig($this->getRootPackage());
         if (isset($config['recurse'])) {
             $this->recurse = (bool)$config['recurse'];
+        }
+        if (isset($config['replace'])) {
+            $this->replace = (bool)$config['replace'];
         }
         if ($config['include']) {
             $this->loader = new ArrayLoader();
@@ -433,7 +446,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     protected function mergeLinks(array $origin, array $merge, array &$dups)
     {
         foreach ($merge as $name => $link) {
-            if (!isset($origin[$name])) {
+            if (!isset($origin[$name]) || $this->replace) {
                 $this->debug("Merging <comment>{$name}</comment>");
                 $origin[$name] = $link;
             } else {

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -114,6 +114,44 @@ class MergePluginTest extends \Prophecy\PhpUnit\ProphecyTestCase
     }
 
     /**
+     * Given a root package with requires
+     *   and a composer.local.json with requires
+     *   and the same package is listed in multiple files
+     * When the plugin is run
+     * Then the root package should inherit the non-conflicting requires
+     *   and conflicting requires should be resolved 'last defined wins'.
+     */
+    public function testMergeWithReplace()
+    {
+        $that = $this;
+        $dir = $this->fixtureDir(__FUNCTION__);
+
+        $root = $this->rootFromJson("{$dir}/composer.json");
+
+        $root->setRequires(Argument::type('array'))->will(
+            function ($args) use ($that) {
+                $requires = $args[0];
+                $that->assertEquals(2, count($requires));
+                $that->assertArrayHasKey('monolog/monolog', $requires);
+                $that->assertEquals(
+                    '1.10.0',
+                    $requires['monolog/monolog']->getPrettyConstraint()
+                );
+            }
+        );
+
+        $root->getDevRequires()->shouldNotBeCalled();
+        $root->getRepositories()->shouldNotBeCalled();
+        $root->getSuggests()->shouldNotBeCalled();
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+
+        $this->assertEquals(0, count($extraInstalls));
+    }
+
+
+
+    /**
      * Given a root package with no requires
      *   and a composer.local.json with one require, which includes a composer.local.2.json
      *   and a composer.local.2.json with one additional require
@@ -432,6 +470,47 @@ class MergePluginTest extends \Prophecy\PhpUnit\ProphecyTestCase
         $getRootPackage->setAccessible(true);
         $this->assertEquals($root, $getRootPackage->invoke($this->fixture));
     }
+
+
+    /**
+     * Given a root package with requires
+     *   and a b.json with requires
+     *   and an a.json with requires
+     *   and a glob of json files with requires
+     * When the plugin is run
+     * Then the root package should inherit the requires
+     *   in the correct order based on inclusion order
+     *   for individual files and alpha-numeric sorting
+     *   for files included via a glob.
+     *
+     * @return void
+     */
+    public function testCorrectMergeOrderOfSpecifiedFilesAndGlobFiles()
+    {
+        $that = $this;
+        $dir = $this->fixtureDir(__FUNCTION__);
+        $root = $this->rootFromJson("{$dir}/composer.json");
+
+        $expects = array(
+            "merge-plugin/b.json",
+            "merge-plugin/a.json",
+            "merge-plugin/glob-a-glob2.json",
+            "merge-plugin/glob-b-glob1.json"
+        );
+
+        $root->setRequires(Argument::type('array'))->will(
+            function ($args) use ($that, &$expects) {
+                $expectedSource = array_shift($expects);
+                $that->assertEquals(
+                    $expectedSource,
+                    $args[0]['wibble/wobble']->getSource()
+                );
+            }
+        );
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+    }
+
+
 
     /**
      * @param RootPackage $package

--- a/tests/phpunit/fixtures/testCorrectMergeOrderOfSpecifiedFilesAndGlobFiles/a.json
+++ b/tests/phpunit/fixtures/testCorrectMergeOrderOfSpecifiedFilesAndGlobFiles/a.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "wikimedia/composer-merge-plugin": "dev-master"
+    },
+    "require": {
+        "wibble/wobble":"3.0"
+    }
+}

--- a/tests/phpunit/fixtures/testCorrectMergeOrderOfSpecifiedFilesAndGlobFiles/b.json
+++ b/tests/phpunit/fixtures/testCorrectMergeOrderOfSpecifiedFilesAndGlobFiles/b.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "wikimedia/composer-merge-plugin": "dev-master"
+    },
+    "require": {
+        "wibble/wobble":"2.0"
+    }
+}

--- a/tests/phpunit/fixtures/testCorrectMergeOrderOfSpecifiedFilesAndGlobFiles/composer.json
+++ b/tests/phpunit/fixtures/testCorrectMergeOrderOfSpecifiedFilesAndGlobFiles/composer.json
@@ -1,0 +1,18 @@
+{
+    "require": {
+        "wikimedia/composer-merge-plugin": "dev-master"
+    },
+    "require": {
+        "wibble/wobble":"1.0"
+    },
+    "extra": {
+        "merge-plugin": {
+            "replace" : true,
+            "include": [
+                "b.json",
+                "a.json",
+                "glob/*.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testCorrectMergeOrderOfSpecifiedFilesAndGlobFiles/glob/a-glob2.json
+++ b/tests/phpunit/fixtures/testCorrectMergeOrderOfSpecifiedFilesAndGlobFiles/glob/a-glob2.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "wikimedia/composer-merge-plugin": "dev-master"
+    },
+    "require": {
+        "wibble/wobble":"4.0"
+    }
+}

--- a/tests/phpunit/fixtures/testCorrectMergeOrderOfSpecifiedFilesAndGlobFiles/glob/b-glob1.json
+++ b/tests/phpunit/fixtures/testCorrectMergeOrderOfSpecifiedFilesAndGlobFiles/glob/b-glob1.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "wikimedia/composer-merge-plugin": "dev-master"
+    },
+    "require": {
+        "wibble/wobble":"5.0"
+    }
+}

--- a/tests/phpunit/fixtures/testMergeWithReplace/composer.json
+++ b/tests/phpunit/fixtures/testMergeWithReplace/composer.json
@@ -1,0 +1,20 @@
+{
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "./.."
+        }
+    ],
+    "require": {
+        "wikimedia/composer-merge-plugin": "*@dev",
+        "monolog/monolog": "~1.0"
+    },
+    "extra": {
+        "merge-plugin": {
+            "replace" : true,
+            "include": [
+                "composer.local.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testMergeWithReplace/composer.local.json
+++ b/tests/phpunit/fixtures/testMergeWithReplace/composer.local.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "monolog/monolog": "1.10.0"
+    }
+}


### PR DESCRIPTION
Introduce a new `extra.merge-plugin.replace` configuration directive
that can be used to change the default conflict resolution mechanism.
When enabled, duplicate package declarations in merged files will
overwrite the declarations made in earlier files. Files are loaded in
the order specified in `extra.merge-plugin.include` with globbed files
being loaded in alphabetical order.

This behavior can be used to replace a default stable package with a dev
or beta version of the same package for testing.

Closes #45
Supersedes #46, #44