### PR TITLE
Add support for merging "extras" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Usage
                 "extensions/*/composer.json"
             ],
             "recurse": false,
-            "replace": false
+            "replace": false,
+            "merge-extra": false
         }
     }
 }
@@ -45,6 +46,16 @@ functionality can be disabled by setting `"recurse": false` inside the
 The "require", "require-dev", "repositories" and "suggest" sections of the
 found configuration files will be merged into the root package configuration
 as though they were directly included in the top-level composer.json file.
+
+The `"merge-extra": true` setting enables the merging of the "extra" section.
+The normal merge mode for the extra section is to accept the first version of
+any key found (e.g. a key in the master config wins over the version found in
+an imported config). If `replace` mode is active (see below) then this behaviour
+changes and the last found key will win (the key in the master config is
+replaced by the key in the imported config). Note that the `merge-plugin`
+key itself is excluded from this merge process. Your mileage with merging the
+extra section will vary depending on the plugins being used and the order in
+which they are processed by Composer.
 
 By default, Composer's normal conflict resolution engine is used to determine
 which version of a package should be installed if multiple files specify the

--- a/tests/phpunit/fixtures/testMergeExtra/composer.json
+++ b/tests/phpunit/fixtures/testMergeExtra/composer.json
@@ -1,0 +1,8 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "merge-extra": true,
+            "include": "composer.local.json"
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testMergeExtra/composer.local.json
+++ b/tests/phpunit/fixtures/testMergeExtra/composer.local.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "ignored": true,
+            "include": []
+        },
+        "wibble": "wobble"
+    }
+}

--- a/tests/phpunit/fixtures/testMergeExtraConflict/composer.json
+++ b/tests/phpunit/fixtures/testMergeExtraConflict/composer.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "merge-extra": true,
+            "include": "composer.local.json"
+        },
+        "wibble": "wobble"
+    }
+}

--- a/tests/phpunit/fixtures/testMergeExtraConflict/composer.local.json
+++ b/tests/phpunit/fixtures/testMergeExtraConflict/composer.local.json
@@ -1,0 +1,5 @@
+{
+    "extra": {
+        "wibble": "ping"
+    }
+}

--- a/tests/phpunit/fixtures/testMergeExtraConflictReplace/composer.json
+++ b/tests/phpunit/fixtures/testMergeExtraConflictReplace/composer.json
@@ -1,0 +1,10 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "replace": true,
+            "merge-extra": true,
+            "include": "composer.local.json"
+        },
+        "wibble": "wobble"
+    }
+}

--- a/tests/phpunit/fixtures/testMergeExtraConflictReplace/composer.local.json
+++ b/tests/phpunit/fixtures/testMergeExtraConflictReplace/composer.local.json
@@ -1,0 +1,5 @@
+{
+    "extra": {
+        "wibble": "ping"
+    }
+}


### PR DESCRIPTION
Introduce a new `extra.merge-plugin.merge-extra` to optionally enable
merging of "extra" sections found in composer.json files. Default merge
behavior is first value wins with duplicate values triggering warnings
when `--verbose` mode is enabled. When the `replace` mode is enabled via
`extra.merge-plugin.replace: true` the merge strategy will change to
last value wins. The utility of merging "extra" sections is not well
specified and will depend on the plugins in use and the processing order
of Composer for all installed plugins.

Closes #49
Supersedes #48