### PR TITLE
Split ever growing MergePlugin into more manageable chunks

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of the Composer Merge plugin.
+ *
+ * Copyright (C) 2015 Bryan Davis, Wikimedia Foundation, and contributors
+ *
+ * This software may be modified and distributed under the terms of the MIT
+ * license. See the LICENSE file for details.
+ */
+
+namespace Wikimedia\Composer;
+
+use Composer\IO\IOInterface;
+
+/**
+ * Simple logging wrapper for Composer\IO\IOInterface
+ *
+ * @author Bryan Davis <bd808@bd808.com>
+ */
+class Logger
+{
+    /**
+     * @var string $name
+     */
+    protected $name;
+
+    /**
+     * @var IOInterface $inputOutput
+     */
+    protected $inputOutput;
+
+    /**
+     * @param string $name
+     * @param IOInterface $io
+     */
+    public function __construct($name, IOInterface $io)
+    {
+        $this->name = $name;
+        $this->inputOutput = $io;
+    }
+
+    /**
+     * Log a debug message
+     *
+     * Messages will be output at the "verbose" logging level (eg `-v` needed
+     * on the Composer command).
+     *
+     * @param string $message
+     */
+    public function debug($message)
+    {
+        if ($this->inputOutput->isVerbose()) {
+            $message = "  <info>[{$this->name}]</info> {$message}";
+
+            if (method_exists($this->inputOutput, 'writeError')) {
+                $this->inputOutput->writeError($message);
+            } else {
+                // @codeCoverageIgnoreStart
+                // Backwards compatiblity for Composer before cb336a5
+                $this->inputOutput->write($message);
+                // @codeCoverageIgnoreEnd
+            }
+        }
+    }
+}
+// vim:sw=4:ts=4:sts=4:et:

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -1,0 +1,387 @@
+<?php
+/**
+ * This file is part of the Composer Merge plugin.
+ *
+ * Copyright (C) 2015 Bryan Davis, Wikimedia Foundation, and contributors
+ *
+ * This software may be modified and distributed under the terms of the MIT
+ * license. See the LICENSE file for details.
+ */
+
+namespace Wikimedia\Composer\Merge;
+
+use Wikimedia\Composer\Logger;
+
+use Composer\Composer;
+use Composer\Json\JsonFile;
+use Composer\Package\BasePackage;
+use Composer\Package\CompletePackage;
+use Composer\Package\Loader\ArrayLoader;
+use Composer\Package\RootPackage;
+use Composer\Package\Version\VersionParser;
+use UnexpectedValueException;
+
+/**
+ * Processing for a composer.json file that will be merged into a RootPackage
+ *
+ * @author Bryan Davis <bd808@bd808.com>
+ */
+class ExtraPackage
+{
+
+    /**
+     * @var Composer $composer
+     */
+    protected $composer;
+
+    /**
+     * @var Logger $logger
+     */
+    protected $logger;
+
+    /**
+     * @var string $path
+     */
+    protected $path;
+
+    /**
+     * @var array $json
+     */
+    protected $json;
+
+    /**
+     * @var CompletePackage $package
+     */
+    protected $package;
+
+    /**
+     * @param string $path Path to composer.json file
+     * @param Composer $composer
+     * @param Logger $logger
+     */
+    public function __construct($path, Composer $composer, Logger $logger)
+    {
+        $this->path = $path;
+        $this->composer = $composer;
+        $this->logger = $logger;
+        $this->json = $this->readPackageJson($path);
+        $this->package = $this->loadPackage($this->json);
+    }
+
+    /**
+     * Get list of additional packages to include if precessing recursively.
+     *
+     * @return array
+     */
+    public function getIncludes()
+    {
+        return isset($this->json['extra']['merge-plugin']['include']) ?
+            $this->json['extra']['merge-plugin']['include'] : array();
+    }
+
+    /**
+     * Read the contents of a composer.json style file into an array.
+     *
+     * The package contents are fixed up to be usable to create a Package
+     * object by providing dummy "name" and "version" values if they have not
+     * been provided in the file. This is consistent with the default root
+     * package loading behavior of Composer.
+     *
+     * @param string $path
+     * @return array
+     */
+    protected function readPackageJson($path)
+    {
+        $file = new JsonFile($path);
+        $json = $file->read();
+        if (!isset($json['name'])) {
+            $json['name'] = 'merge-plugin/' .
+                strtr($path, DIRECTORY_SEPARATOR, '-');
+        }
+        if (!isset($json['version'])) {
+            $json['version'] = '1.0.0';
+        }
+        return $json;
+    }
+
+    /**
+     * @return CompletePackage
+     */
+    protected function loadPackage($json)
+    {
+        $loader = new ArrayLoader();
+        $package = $loader->load($json);
+        // @codeCoverageIgnoreStart
+        if (!$package instanceof CompletePackage) {
+            throw new UnexpectedValueException(
+                'Expected instance of CompletePackage, got ' .
+                get_class($package)
+            );
+        }
+        // @codeCoverageIgnoreEnd
+        return $package;
+    }
+
+    /**
+     * Merge this package into a RootPackage
+     *
+     * @param RootPackage $root
+     * @param PluginState $state
+     */
+    public function mergeInto(RootPackage $root, PluginState $state)
+    {
+        $this->mergeRequires($root, $state);
+        $this->mergeDevRequires($root, $state);
+
+        $this->mergeAutoload($root);
+        $this->mergeDevAutoload($root);
+
+        $this->addRepositories($root);
+
+        $this->mergeExtra($root, $state);
+        $this->mergeSuggests($root);
+        // TODO: provide, replace, conflict
+    }
+
+    /**
+     * Merge require into a RootPackage
+     *
+     * @param RootPackage $root
+     * @param PluginState $state
+     */
+    protected function mergeRequires(RootPackage $root, PluginState $state)
+    {
+        $requires = $this->package->getRequires();
+        if (empty($requires)) {
+            return;
+        }
+
+        $this->mergeStabilityFlags($root, $requires);
+
+        $dups = array();
+        $root->setRequires($this->mergeLinks(
+            $root->getRequires(),
+            $requires,
+            $state->replaceDuplicateLinks(),
+            $dups
+        ));
+        $state->addDuplicateLinks('require', $dups);
+    }
+
+    /**
+     * Merge require-dev into RootPackage
+     *
+     * @param RootPackage $root
+     * @param PluginState $state
+     */
+    protected function mergeDevRequires(RootPackage $root, PluginState $state)
+    {
+        $requires = $this->package->getDevRequires();
+        if (empty($requires)) {
+            return;
+        }
+
+        $this->mergeStabilityFlags($root, $requires);
+
+        $dups = array();
+        $root->setDevRequires($this->mergeLinks(
+            $root->getDevRequires(),
+            $requires,
+            $state->replaceDuplicateLinks(),
+            $dups
+        ));
+        $state->addDuplicateLinks('require-dev', $dups);
+    }
+
+    /**
+     * Merge two collections of package links and collect duplicates for
+     * subsequent processing.
+     *
+     * @param array $origin Primary collection
+     * @param array $merge Additional collection
+     * @param bool $replace Replace exising links?
+     * @param array &dups Duplicate storage
+     * @return array Merged collection
+     */
+    protected function mergeLinks(
+        array $origin,
+        array $merge,
+        $replace,
+        array &$dups
+    ) {
+        foreach ($merge as $name => $link) {
+            if (!isset($origin[$name]) || $replace) {
+                $this->logger->debug("Merging <comment>{$name}</comment>");
+                $origin[$name] = $link;
+            } else {
+                // Defer to solver.
+                $this->logger->debug(
+                    "Deferring duplicate <comment>{$name}</comment>"
+                );
+                $dups[] = $link;
+            }
+        }
+        return $origin;
+    }
+
+    /**
+     * Merge autoload into a RootPackage
+     *
+     * @param RootPackage $root
+     */
+    protected function mergeAutoload(RootPackage $root)
+    {
+        $autoload = $this->package->getAutoload();
+        if (empty($autoload)) {
+            return;
+        }
+
+        $this->prependPath($this->path, $autoload);
+
+        $root->setAutoload(array_merge_recursive(
+            $root->getAutoload(),
+            $autoload
+        ));
+    }
+
+    /**
+     * Merge autoload-dev into a RootPackage
+     *
+     * @param RootPackage $root
+     */
+    protected function mergeDevAutoload(RootPackage $root)
+    {
+        $autoload = $this->package->getDevAutoload();
+        if (empty($autoload)) {
+            return;
+        }
+
+        $this->prependPath($this->path, $autoload);
+
+        $root->setDevAutoload(array_merge_recursive(
+            $root->getDevAutoload(),
+            $autoload
+        ));
+    }
+
+    /**
+     * Prepend a path to a collection of paths.
+     *
+     * @param string $basePath
+     * @param array $paths
+     */
+    protected function prependPath($basePath, array &$paths)
+    {
+        $basePath = substr($basePath, 0, strrpos($basePath, '/') + 1);
+
+        array_walk_recursive(
+            $paths,
+            function (&$localPath) use ($basePath) {
+                $localPath = $basePath . $localPath;
+            }
+        );
+    }
+
+    /**
+     * Extract and merge stability flags from the given collection of
+     * requires and merge them into a RootPackage
+     *
+     * @param RootPackage $root
+     * @param array $requires
+     */
+    protected function mergeStabilityFlags(
+        RootPackage $root,
+        array $requires
+    ) {
+        $flags = $root->getStabilityFlags();
+        foreach ($requires as $name => $link) {
+            $name = strtolower($name);
+            $version = $link->getPrettyConstraint();
+            $stability = VersionParser::parseStability($version);
+            $flags[$name] = BasePackage::$stabilities[$stability];
+        }
+        $root->setStabilityFlags($flags);
+    }
+
+    /**
+     * Add a collection of repositories described by the given configuration
+     * to the given package and the global repository manager.
+     *
+     * @param RootPackage $root
+     */
+    protected function addRepositories(RootPackage $root)
+    {
+        if (!isset($this->json['repositories'])) {
+            return;
+        }
+        $repoManager = $this->composer->getRepositoryManager();
+        $newRepos = array();
+
+        foreach ($this->json['repositories'] as $repoJson) {
+            if (!isset($repoJson['type'])) {
+                continue;
+            }
+            $this->logger->debug("Adding {$repoJson['type']} repository");
+            $repo = $repoManager->createRepository(
+                $repoJson['type'],
+                $repoJson
+            );
+            $repoManager->addRepository($repo);
+            $newRepos[] = $repo;
+        }
+
+        $root->setRepositories(array_merge(
+            $newRepos,
+            $root->getRepositories()
+        ));
+    }
+
+    /**
+     * Merge extra config into a RootPackage
+     *
+     * @param RootPackage $root
+     * @param PluginState $state
+     */
+    public function mergeExtra(RootPackage $root, PluginState $state)
+    {
+        $extra = $this->package->getExtra();
+        unset($extra['merge-plugin']);
+        if (!$state->shouldMergeExtra() || empty($extra)) {
+            return;
+        }
+
+        $rootExtra = $root->getExtra();
+
+        if ($state->replaceDuplicateLinks()) {
+            $root->setExtra(array_merge($rootExtra, $extra));
+
+        } else {
+            foreach ($extra as $key => $value) {
+                if (isset($rootExtra[$key])) {
+                    $this->logger->debug(
+                        "Ignoring duplicate <comment>{$key}</comment> in ".
+                        "<comment>{$this->path}</comment> extra config."
+                    );
+                }
+            }
+            $root->setExtra(array_merge($extra, $rootExtra));
+        }
+    }
+
+    /**
+     * Merge suggested packages into a RootPackage
+     *
+     * @param RootPackage $root
+     */
+    protected function mergeSuggests(RootPackage $root)
+    {
+        $suggests = $this->package->getSuggests();
+        if (!empty($suggests)) {
+            $root->setSuggests(array_merge(
+                $root->getSuggests(),
+                $suggests
+            ));
+        }
+    }
+}
+// vim:sw=4:ts=4:sts=4:et:

--- a/src/Merge/PluginState.php
+++ b/src/Merge/PluginState.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * This file is part of the Composer Merge plugin.
+ *
+ * Copyright (C) 2015 Bryan Davis, Wikimedia Foundation, and contributors
+ *
+ * This software may be modified and distributed under the terms of the MIT
+ * license. See the LICENSE file for details.
+ */
+
+namespace Wikimedia\Composer\Merge;
+
+use Composer\Composer;
+use Composer\Package\AliasPackage;
+use Composer\Package\RootPackage;
+use UnexpectedValueException;
+
+/**
+ * Mutable plugin state
+ *
+ * @author Bryan Davis <bd808@bd808.com>
+ */
+class PluginState
+{
+    /**
+     * @var Composer $composer
+     */
+    protected $composer;
+
+    /**
+     * @var array $includes
+     */
+    protected $includes = array();
+
+    /**
+     * @var array $duplicateLinks
+     */
+    protected $duplicateLinks = array();
+
+    /**
+     * @var bool $devMode
+     */
+    protected $devMode = false;
+
+    /**
+     * @var bool $recurse
+     */
+    protected $recurse = true;
+
+    /**
+     * @var bool $replace
+     */
+    protected $replace = false;
+
+    /**
+     * Whether to merge the extra section.
+     *
+     * By default, the extra section is not merged and there will be many
+     * cases where the merge of the extra section is performed too late
+     * to be of use to other plugins. When enabled, merging uses one of
+     * two strategies - either 'first wins' or 'last wins'. When enabled,
+     * 'first wins' is the default behaviour. If Replace mode is activated
+     * then 'last wins' is used.
+     *
+     * @var bool $mergeExtra
+     */
+    protected $mergeExtra = false;
+
+    /**
+     * @var bool $firstInstall
+     */
+    protected $firstInstall = false;
+
+    /**
+     * @var bool $locked
+     */
+    protected $locked = false;
+
+    /**
+     * @var bool $dumpAutoloader
+     */
+    protected $dumpAutoloader = false;
+
+    /**
+     * @var bool $optimizeAutoloader
+     */
+    protected $optimizeAutoloader = false;
+
+    /**
+     * @param Composer $composer
+     */
+    public function __construct(Composer $composer)
+    {
+        $this->composer = $composer;
+    }
+
+    /**
+     * Load plugin settings
+     */
+    public function loadSettings()
+    {
+        $extra = $this->getRootPackage()->getExtra();
+        $config = array_merge(
+            array(
+                'include' => array(),
+                'recurse' => true,
+                'replace' => false,
+                'merge-extra' => false,
+            ),
+            isset($extra['merge-plugin']) ? $extra['merge-plugin'] : array()
+        );
+
+        $this->includes = (is_array($config['include'])) ?
+            $config['include'] : array($config['include']);
+        $this->recurse = (bool)$config['recurse'];
+        $this->replace = (bool)$config['replace'];
+        $this->mergeExtra = (bool)$config['merge-extra'];
+    }
+
+    /**
+     * Get the root package
+     *
+     * @return RootPackage
+     */
+    public function getRootPackage()
+    {
+        $root = $this->composer->getPackage();
+        if ($root instanceof AliasPackage) {
+            $root = $root->getAliasOf();
+        }
+        // @codeCoverageIgnoreStart
+        if (!$root instanceof RootPackage) {
+            throw new UnexpectedValueException(
+                'Expected instance of RootPackage, got ' .
+                get_class($root)
+            );
+        }
+        // @codeCoverageIgnoreEnd
+        return $root;
+    }
+
+    /**
+     * Get list of filenames and/or glob patterns to include
+     *
+     * @return array
+     */
+    public function getIncludes()
+    {
+        return $this->includes;
+    }
+
+    /**
+     * Set the first install flag
+     *
+     * @param bool $flag
+     */
+    public function setFirstInstall($flag)
+    {
+        $this->firstInstall = (bool)$flag;
+    }
+
+    /**
+     * Is this the first time that the plugin has been installed?
+     *
+     * @return bool
+     */
+    public function isFirstInstall()
+    {
+        return $this->firstInstall;
+    }
+
+    /**
+     * Set the locked flag
+     *
+     * @param bool $flag
+     */
+    public function setLocked($flag)
+    {
+        $this->locked = (bool)$flag;
+    }
+
+    /**
+     * Was a lockfile present when the plugin was installed?
+     *
+     * @return bool
+     */
+    public function isLocked()
+    {
+        return $this->locked;
+    }
+
+    /**
+     * Should an update be forced?
+     *
+     * @return true If packages are not locked
+     */
+    public function forceUpdate()
+    {
+        return !$this->locked;
+    }
+
+    /**
+     * Set the devMode flag
+     *
+     * @param bool $flag
+     */
+    public function setDevMode($flag)
+    {
+        $this->devMode = (bool)$flag;
+    }
+
+    /**
+     * Should devMode settings be processed?
+     *
+     * @return bool
+     */
+    public function isDevMode()
+    {
+        return $this->devMode;
+    }
+
+    /**
+     * Set the dumpAutoloader flag
+     *
+     * @param bool $flag
+     */
+    public function setDumpAutoloader($flag)
+    {
+        $this->dumpAutoloader = (bool)$flag;
+    }
+
+    /**
+     * Is the autoloader file supposed to be written out?
+     *
+     * @return bool
+     */
+    public function shouldDumpAutoloader()
+    {
+        return $this->dumpAutoloader;
+    }
+
+    /**
+     * Set the optimizeAutoloader flag
+     *
+     * @param bool $flag
+     */
+    public function setOptimizeAutoloader($flag)
+    {
+        $this->optimizeAutoloader = (bool)$flag;
+    }
+
+    /**
+     * Should the autoloader be optimized?
+     *
+     * @return bool
+     */
+    public function shouldOptimizeAutoloader()
+    {
+        return $this->optimizeAutoloader;
+    }
+
+    /**
+     * Add duplicate packages
+     *
+     * @param string $type Package type
+     * @param array $packages
+     */
+    public function addDuplicateLinks($type, array $packages)
+    {
+        if (!isset($this->duplicateLinks[$type])) {
+            $this->duplicateLinks[$type] = array();
+        }
+        $this->duplicateLinks[$type] =
+            array_merge($this->duplicateLinks[$type], $packages);
+    }
+
+    /**
+     * Get duplicate packages
+     *
+     * @param string $type Package type
+     * @return array
+     */
+    public function getDuplicateLinks($type)
+    {
+        return isset($this->duplicateLinks[$type]) ?
+            $this->duplicateLinks[$type] : array();
+    }
+
+    /**
+     * Should includes be recursively processed?
+     *
+     * @return bool
+     */
+    public function recurseIncludes()
+    {
+        return $this->recurse;
+    }
+
+    /**
+     * Should duplicate links be replaced in a 'last definition wins' order?
+     *
+     * @return bool
+     */
+    public function replaceDuplicateLinks()
+    {
+        return $this->replace;
+    }
+
+    /**
+     * Should the extra section be merged?
+     *
+     * By default, the extra section is not merged and there will be many
+     * cases where the merge of the extra section is performed too late
+     * to be of use to other plugins. When enabled, merging uses one of
+     * two strategies - either 'first wins' or 'last wins'. When enabled,
+     * 'first wins' is the default behaviour. If Replace mode is activated
+     * then 'last wins' is used.
+     *
+     * @return bool
+     */
+    public function shouldMergeExtra()
+    {
+        return $this->mergeExtra;
+    }
+}
+// vim:sw=4:ts=4:sts=4:et:

--- a/tests/phpunit/LoggerTest.php
+++ b/tests/phpunit/LoggerTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of the Composer Merge plugin.
+ *
+ * Copyright (C) 2015 Bryan Davis, Wikimedia Foundation, and contributors
+ *
+ * This software may be modified and distributed under the terms of the MIT
+ * license. See the LICENSE file for details.
+ */
+
+namespace Wikimedia\Composer;
+
+use Composer\IO\IOInterface;
+use Prophecy\Argument;
+
+/**
+ * @covers Wikimedia\Composer\Logger
+ */
+class LoggerTest extends \Prophecy\PhpUnit\ProphecyTestCase
+{
+
+    public function testVerboseDebug()
+    {
+        $output = array();
+        $io = $this->prophesize('Composer\IO\IOInterface');
+        $io->isVerbose()->willReturn(true)->shouldBeCalled();
+        $io->writeError(Argument::type('string'))->will(
+            function ($args) use (&$output) {
+                $output[] = $args[0];
+            }
+        )->shouldBeCalled();
+        $io->write(Argument::type('string'))->shouldNotBeCalled();
+
+        $fixture = new Logger('test', $io->reveal());
+        $fixture->debug('foo');
+        $this->assertEquals(1, count($output));
+        $this->assertContains('<info>[test]</info>', $output[0]);
+    }
+
+    public function testNotVerboseDebug()
+    {
+        $output = array();
+        $io = $this->prophesize('Composer\IO\IOInterface');
+        $io->isVerbose()->willReturn(false)->shouldBeCalled();
+        $io->writeError(Argument::type('string'))->shouldNotBeCalled();
+        $io->write(Argument::type('string'))->shouldNotBeCalled();
+
+        $fixture = new Logger('test', $io->reveal());
+        $fixture->debug('foo');
+    }
+}
+// vim:sw=4:ts=4:sts=4:et:

--- a/tests/phpunit/Merge/PluginStateTest.php
+++ b/tests/phpunit/Merge/PluginStateTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Composer Merge plugin.
+ *
+ * Copyright (C) 2015 Bryan Davis, Wikimedia Foundation, and contributors
+ *
+ * This software may be modified and distributed under the terms of the MIT
+ * license. See the LICENSE file for details.
+ */
+
+namespace Wikimedia\Composer\Merge;
+
+use Composer\Composer;
+
+/**
+ * @covers Wikimedia\Composer\Merge\PluginState
+ */
+class PluginStateTest extends \Prophecy\PhpUnit\ProphecyTestCase
+{
+
+    public function testLocked()
+    {
+        $composer = $this->prophesize('Composer\Composer')->reveal();
+        $fixture = new PluginState($composer);
+
+        $this->assertFalse($fixture->isLocked());
+        $this->assertTrue($fixture->forceUpdate());
+
+        $fixture->setLocked(true);
+        $this->assertTrue($fixture->isLocked());
+        $this->assertFalse($fixture->forceUpdate());
+    }
+
+    public function testDumpAutoloader()
+    {
+        $composer = $this->prophesize('Composer\Composer')->reveal();
+        $fixture = new PluginState($composer);
+
+        $this->assertFalse($fixture->shouldDumpAutoloader());
+
+        $fixture->setDumpAutoloader(true);
+        $this->assertTrue($fixture->shouldDumpAutoloader());
+    }
+
+    public function testOptimizeAutoloader()
+    {
+        $composer = $this->prophesize('Composer\Composer')->reveal();
+        $fixture = new PluginState($composer);
+
+        $this->assertFalse($fixture->shouldOptimizeAutoloader());
+
+        $fixture->setOptimizeAutoloader(true);
+        $this->assertTrue($fixture->shouldOptimizeAutoloader());
+    }
+}
+// vim:sw=4:ts=4:sts=4:et:


### PR DESCRIPTION
MergePlugin started out as a mostly reasonable 225 line file but has
since ballooned to 660+ lines as features have been added. Start to chip
away at this by splitting the class into 4 parts:

* Wikimedia\Composer\MergePlugin: core Composer plugin methods
* Wikimedia\Composer\Logger: Wrapper for IOInterface
* Wikimedia\Composer\Merge\ExtraPackage: Core merge logic
* Wikimedia\Composer\Merge\PluginState: Configuration and runtime state

There is probably more work to be done here, but it feels a bit cleaner.