### PR TITLE
Add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,10 @@
         }
     },
     "extra": {
-        "class": "Wikimedia\\Composer\\MergePlugin"
+        "class": "Wikimedia\\Composer\\MergePlugin",
+        "branch-alias": {
+            "dev-master": "1.2.x-dev"
+        }
     },
     "config": {
         "optimize-autoloader": true


### PR DESCRIPTION
This means we can require `~1.2@dev` rather than having to use `dev-master`.

It does mean that you'll need to keep it updated.