### PR TITLE
Add branch alias for master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=5.3.2",
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^1.0",
+        "php": ">=5.3.2"
     },
     "require-dev": {
         "composer/composer": "1.0.*@dev",
-        "phpunit/phpunit": "~4.0",
         "jakub-onderka/php-parallel-lint": "~0.8",
-        "squizlabs/php_codesniffer": "~2.1.0",
-        "phpspec/prophecy-phpunit": "~1.0"
+        "phpspec/prophecy-phpunit": "~1.0",
+        "phpunit/phpunit": "~4.0",
+        "squizlabs/php_codesniffer": "~2.1.0"
     },
     "autoload": {
         "psr-4": {
@@ -28,6 +28,9 @@
         }
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "1.3.x-dev"
+        },
         "class": "Wikimedia\\Composer\\MergePlugin"
     },
     "config": {


### PR DESCRIPTION
Having a branch alias allows us to associate a semantic version number
with the development branch. This can be used by a consuming project to
follow the latest unreleased version while still retaining the ability
to prevent adoption of major/minor version breaks.

This version number should be bumped concurrently with or just before
pulling new minor version changing commits into the master branch. The
current master branch is progressing towards the 1.3.0 release milestone
so we will start with "1.3.x" as the alias. This can remain until we
start to bring in changes for the 1.4.0 release.

More details at <https://getcomposer.org/doc/articles/aliases.md>