### PR TITLE
Handle RootAliasPackage as correctly as we can

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -51,15 +51,35 @@ class Logger
     {
         if ($this->inputOutput->isVerbose()) {
             $message = "  <info>[{$this->name}]</info> {$message}";
+            $this->log($message);
+        }
+    }
 
-            if (method_exists($this->inputOutput, 'writeError')) {
-                $this->inputOutput->writeError($message);
-            } else {
-                // @codeCoverageIgnoreStart
-                // Backwards compatiblity for Composer before cb336a5
-                $this->inputOutput->write($message);
-                // @codeCoverageIgnoreEnd
-            }
+    /**
+     * Log a warning message
+     *
+     * @param string $message
+     */
+    public function warning($message)
+    {
+        $message = "  <error>[{$this->name}]</error> {$message}";
+        $this->log($message);
+    }
+
+    /**
+     * Write a message
+     *
+     * @param string $message
+     */
+    protected function log($message)
+    {
+        if (method_exists($this->inputOutput, 'writeError')) {
+            $this->inputOutput->writeError($message);
+        } else {
+            // @codeCoverageIgnoreStart
+            // Backwards compatiblity for Composer before cb336a5
+            $this->inputOutput->write($message);
+            // @codeCoverageIgnoreEnd
         }
     }
 }

--- a/src/Merge/PluginState.php
+++ b/src/Merge/PluginState.php
@@ -11,9 +11,6 @@
 namespace Wikimedia\Composer\Merge;
 
 use Composer\Composer;
-use Composer\Package\AliasPackage;
-use Composer\Package\RootPackage;
-use UnexpectedValueException;
 
 /**
  * Mutable plugin state
@@ -99,7 +96,7 @@ class PluginState
      */
     public function loadSettings()
     {
-        $extra = $this->getRootPackage()->getExtra();
+        $extra = $this->composer->getPackage()->getExtra();
         $config = array_merge(
             array(
                 'include' => array(),
@@ -115,28 +112,6 @@ class PluginState
         $this->recurse = (bool)$config['recurse'];
         $this->replace = (bool)$config['replace'];
         $this->mergeExtra = (bool)$config['merge-extra'];
-    }
-
-    /**
-     * Get the root package
-     *
-     * @return RootPackage
-     */
-    public function getRootPackage()
-    {
-        $root = $this->composer->getPackage();
-        if ($root instanceof AliasPackage) {
-            $root = $root->getAliasOf();
-        }
-        // @codeCoverageIgnoreStart
-        if (!$root instanceof RootPackage) {
-            throw new UnexpectedValueException(
-                'Expected instance of RootPackage, got ' .
-                get_class($root)
-            );
-        }
-        // @codeCoverageIgnoreEnd
-        return $root;
     }
 
     /**

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -23,7 +23,7 @@ use Composer\Installer\InstallerEvents;
 use Composer\Installer\PackageEvent;
 use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
-use Composer\Package\RootPackage;
+use Composer\Package\RootPackageInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
@@ -159,7 +159,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
      */
     protected function mergeIncludes(array $includes)
     {
-        $root = $this->state->getRootPackage();
+        $root = $this->composer->getPackage();
         foreach (array_reduce(
             array_map('glob', $includes),
             'array_merge',
@@ -172,10 +172,10 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     /**
      * Read a JSON file and merge its contents
      *
-     * @param RootPackage $root
+     * @param RootPackageInterface $root
      * @param string $path
      */
-    protected function mergeFile(RootPackage $root, $path)
+    protected function mergeFile(RootPackageInterface $root, $path)
     {
         if (isset($this->loadedFiles[$path])) {
             $this->logger->debug(

--- a/tests/phpunit/fixtures/testHasBranchAlias/composer.json
+++ b/tests/phpunit/fixtures/testHasBranchAlias/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
+        "monolog/monolog": "^1.0",
         "wikimedia/composer-merge-plugin": "dev-master"
     },
     "extra": {

--- a/tests/phpunit/fixtures/testHasBranchAlias/composer.local.json
+++ b/tests/phpunit/fixtures/testHasBranchAlias/composer.local.json
@@ -1,6 +1,50 @@
 {
     "require": {
-        "php": ">=5.4.0,<5.6.0"
+        "monolog/monolog": "^1.1",
+        "php": ">=5.4.0,<5.6.0",
+        "test/foo": "dev-master"
+    },
+    "require-dev": {
+        "test/a": "*",
+        "test/bar": "1.0.*@beta"
+    },
+    "conflict": {
+        "test/baz": "*"
+    },
+    "replace": {
+        "test/xyzzy": "*"
+    },
+    "provide": {
+        "test/plugh": "*"
+    },
+    "suggest": {
+        "punk/rock": "It's the best kind of rock"
+    },
+    "autoload": {
+        "psr-4": {
+            "Foo\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Foo\\": "src/"
+        }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/bd808/composer-merge-plugin.git"
+        },
+        {
+            "packagist": false
+        }
+    ],
+    "extra": {
+        "merge-plugin": {
+            "ignored": true,
+            "include": []
+        },
+        "wibble": "wobble"
     }
 }
 


### PR DESCRIPTION
When the top level Package includes an "extra.branch-alias" directive
Composer wraps the normal `RootPackage` in a `RootAliasPackage`. This is
done to allow the `RootAliasPackage` to modify the version information
in "require", "require-dev", "conflict", "provide" and "replace" sections
of the package. Unfortunately `RootAliasPackage` does not implement the
complete public API of `RootPackage` so we need to apply special checks
for its presence.

Previously we tried to handle this by immediately unwrapping the aliased
root package and making all operations use it directly. This
unfortunately doesn't work as internally Composer caches data for the
collections that can be modified by the alias in the `RootAliasPackage`
at construction time. This prevents our changes to those collections
from being acted on at runtime.

We fix propagation of "require" and "require-dev" configuration by
operating on the `RootAliasPackage` directly again. For other collection
changing operations we continue to modify the unwrapped package. These
changes should propagate for all but the "conflict", "provide" and
"replace" collections which are cached by the `RootAliasPackage` and not
exposed with setters that allow post-construction modification. If an
aliased package tries to merge these sections we emit a warning via
Composer and continue gracefully.

Closes #62
Co-authored-by: Alexander Polyanskikh <alexander.polyanskikh@claromentis.com>