### PR TITLE
Compute proper autoload paths

### DIFF
--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -272,11 +272,9 @@ class ExtraPackage
             return;
         }
 
-        $this->prependPath($this->path, $autoload);
-
         $root->setAutoload(array_merge_recursive(
             $root->getAutoload(),
-            $autoload
+            $this->fixRelativePaths($autoload)
         ));
     }
 
@@ -292,30 +290,31 @@ class ExtraPackage
             return;
         }
 
-        $this->prependPath($this->path, $autoload);
-
         $root->setDevAutoload(array_merge_recursive(
             $root->getDevAutoload(),
-            $autoload
+            $this->fixRelativePaths($autoload)
         ));
     }
 
     /**
-     * Prepend a path to a collection of paths.
+     * Fix a collection of paths that are relative to this package to be
+     * relative to the base package.
      *
-     * @param string $basePath
      * @param array $paths
+     * @return array
      */
-    protected function prependPath($basePath, array &$paths)
+    protected function fixRelativePaths(array $paths)
     {
-        $basePath = substr($basePath, 0, strrpos($basePath, '/') + 1);
+        $base = dirname($this->path);
+        $base = ($base === '.') ? '' : "{$base}/";
 
         array_walk_recursive(
             $paths,
-            function (&$localPath) use ($basePath) {
-                $localPath = $basePath . $localPath;
+            function (&$path) use ($base) {
+                $path = "{$base}{$path}";
             }
         );
+        return $paths;
     }
 
     /**

--- a/tests/phpunit/fixtures/testMergedAutoload/composer.json
+++ b/tests/phpunit/fixtures/testMergedAutoload/composer.json
@@ -11,7 +11,10 @@
 	},
 	"extra": {
 		"merge-plugin": {
-			"include": "extensions/*/composer.json"
+			"include": [
+				"composer.local.json",
+				"extensions/*/composer.json"
+			]
 		}
 	}
 }

--- a/tests/phpunit/fixtures/testMergedAutoload/composer.local.json
+++ b/tests/phpunit/fixtures/testMergedAutoload/composer.local.json
@@ -1,0 +1,5 @@
+{
+	"autoload": {
+		"files": ["private/bootstrap.php"]
+	}
+}

--- a/tests/phpunit/fixtures/testMergedAutoload/private/bootstrap.php
+++ b/tests/phpunit/fixtures/testMergedAutoload/private/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+function boostrap()
+{
+    echo "Bootstrapped\n";
+}


### PR DESCRIPTION
Fix require/require-dev file path computation for included configuration
files that are in the same directory as the root composer.json. Change
includes minor refactoring to eliminate pass-by-reference semantics and
improve method naming.

Closes #64