### PR TITLE
Update README and doc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,25 @@
 Composer Merge Plugin
 =====================
 
-Merge one or more additional composer.json files at [Composer] runtime.
+Merge multiple composer.json files at [Composer] runtime.
 
 Composer Merge Plugin is intended to allow easier dependency management for
 applications which ship a composer.json file and expect some deployments to
 install additional Composer managed libraries. It does this by allowing the
 application's top level `composer.json` file to provide a list of optional
 additional configuration files. When Composer is run it will parse these files
-and merge their configuration into the base configuration. This combined
-configuration will allow downloading additional libraries and generating the
-autoloader. It was specifically created to help with installation of
-[MediaWiki] which has core Composer managed library requirements and optional
-libraries and extensions which may also be managed via Composer.
+and merge their configuration settings into the base configuration. This
+combined configuration will then be used when downloading additional libraries
+and generating the autoloader.
+
+Composer Merge Plugin was created to help with installation of [MediaWiki]
+which has core library requirements as well as optional libraries and
+extensions which may be managed via Composer.
 
 
 Installation
 ------------
+
 ```
 $ composer require wikimedia/composer-merge-plugin
 ```
@@ -40,7 +43,7 @@ Usage
                 "composer.local.json",
                 "extensions/*/composer.json"
             ],
-            "recurse": false,
+            "recurse": true,
             "replace": false,
             "merge-extra": false
         }
@@ -48,17 +51,25 @@ Usage
 }
 ```
 
-The `include` key can specify either a single value or an array of values.
-Each value is treated as a `glob()` pattern identifying additional
-composer.json style configuration files to merge into the configuration for
-the current Composer execution. By default the merge plugin is recursive, if
-an included file also has a "merge-plugin" section it will also be processed.
-This functionality can be disabled by setting `"recurse": false` inside the
-"merge-plugin" section.
 
-These sections of the found configuration files will be merged into the root
-package configuration as though they were directly included in the top-level
-composer.json file:
+Plugin configuration
+--------------------
+
+The plugin reads its configuration from the `merge-plugin` section of your
+composer.json's `extra` section. An `include` setting is required to tell
+Composer Merge Plugin which file(s) to merge.
+
+
+### include
+
+The `include` setting can specify either a single value or an array of values.
+Each value is treated as a PHP `glob()` pattern identifying additional
+composer.json style configuration files to merge into the root package
+configuration for the current Composer execution.
+
+The following sections of the found configuration files will be merged into
+the Composer root package configuration as though they were directly included
+in the top-level composer.json file:
 
 * [autoload](https://getcomposer.org/doc/04-schema.md#autoload)
 * [autoload-dev](https://getcomposer.org/doc/04-schema.md#autoload-dev)
@@ -69,29 +80,47 @@ composer.json file:
 * [require](https://getcomposer.org/doc/04-schema.md#require)
 * [require-dev](https://getcomposer.org/doc/04-schema.md#require-dev)
 * [suggest](https://getcomposer.org/doc/04-schema.md#suggest)
+* [extra](https://getcomposer.org/doc/04-schema.md#extra) (optional, see
+  [merge-extra](#merge-extra) below)
 
-A `"merge-extra": true` setting enables the merging of the "extra" section of
-included files as well. The normal merge mode for the extra section is to
-accept the first version of any key found (e.g. a key in the master config
-wins over the version found in an imported config). If `replace` mode is
-active (see below) then this behavior changes and the last found key will win
-(the key in the master config is replaced by the key in the imported config).
-Note that the `merge-plugin` key itself is excluded from this merge process.
-Your mileage with merging the extra section will vary depending on the plugins
-being used and the order in which they are processed by Composer.
 
-By default, Composer's normal conflict resolution engine is used to determine
-which version of a package should be installed if multiple files specify the
-same package. A `"replace": true` setting can be provided inside the
-"merge-plugin" section to change to a "last version specified wins" conflict
-resolution strategy. In this mode, duplicate package declarations in merged
-files will overwrite the declarations made in earlier files. Files are loaded
-in the order specified in the `include` section with globbed files being
-loaded in alphabetical order.
+### recurse
+
+By default the merge plugin is recursive; if an included file has
+a `merge-plugin` section it will also be processed. This functionality can be
+disabled by adding a `"recurse": false` setting.
+
+
+### replace
+
+By default, Composer's conflict resolution engine is used to determine which
+version of a package should be installed when multiple files specify the same
+package. A `"replace": true` setting can be provided to change to a "last
+version specified wins" conflict resolution strategy. In this mode, duplicate
+package declarations found in merged files will overwrite the declarations
+made by earlier files. Files are loaded in the order specified by the
+`include` setting with globbed files being processed in alphabetical order.
+
+
+### merge-extra
+
+A `"merge-extra": true` setting enables the merging the contents of the
+`extra` section of included files as well. The normal merge mode for the extra
+section is to accept the first version of any key found (e.g. a key in the
+master config wins over the version found in any imported config). If
+`replace` mode is active ([see above](#replace)) then this behavior changes
+and the last key found will win (e.g. the key in the master config is replaced
+by the key in the imported config). The usefulness of merging the extra
+section will vary depending on the Composer plugins being used and the order
+in which they are processed by Composer.
+
+Note that `merge-plugin` sections are excluded from the merge process, but are
+always processed by the plugin unless [recursion](#recurse) is disabled.
 
 
 Running tests
 -------------
+
 ```
 $ composer install
 $ composer test
@@ -100,6 +129,7 @@ $ composer test
 
 Contributing
 ------------
+
 Bug, feature requests and other issues should be reported to the [GitHub
 project]. We accept code and documentation contributions via Pull Requests on
 GitHub as well.
@@ -119,6 +149,7 @@ GitHub as well.
 
 License
 -------
+
 Composer Merge plugin is licensed under the MIT license. See the `LICENSE`
 file for more details.
 

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -32,13 +32,17 @@ use Composer\Script\ScriptEvents;
  * Composer plugin that allows merging multiple composer.json files.
  *
  * When installed, this plugin will look for a "merge-plugin" key in the
- * composer configuration's "extra" section. The value of this setting can be
- * either a single value or an array of values. Each value is treated as
- * a glob() pattern identifying additional composer.json style configuration
- * files to merge into the configuration for the current compser execution.
+ * composer configuration's "extra" section. The value for this key is
+ * a set of options configuring the plugin.
  *
- * The "require", "require-dev", "repositories", "extra" and "suggest" sections
- * of the found configuration files will be merged into the root package
+ * An "include" setting is required. The value of this setting can be either
+ * a single value or an array of values. Each value is treated as a glob()
+ * pattern identifying additional composer.json style configuration files to
+ * merge into the configuration for the current compser execution.
+ *
+ * The "autoload", "autoload-dev", "conflict", "provide", "replace",
+ * "repositories", "require", "require-dev", and "suggest" sections of the
+ * found configuration files will be merged into the root package
  * configuration as though they were directly included in the top-level
  * composer.json file.
  *
@@ -48,10 +52,10 @@ use Composer\Script\ScriptEvents;
  * change this default behaviour so that the last-defined version of a package
  * will win, allowing for force-overrides of package defines.
  *
- * By default the "extra" section is not merged. This can be enabled with the
- * 'merge-extra' key by setting it to true. In normal mode, when the same key
- * is found in both the original and the imported extra section, the version
- * in the original config is used and the imported version is skipped. If
+ * By default the "extra" section is not merged. This can be enabled by
+ * setitng the 'merge-extra' key to true. In normal mode, when the same key is
+ * found in both the original and the imported extra section, the version in
+ * the original config is used and the imported version is skipped. If
  * 'replace' mode is active, this behaviour changes so the imported version of
  * the key is used, replacing the version in the original config.
  *


### PR DESCRIPTION
* Add sub-section headings for configuration settings
* Fix a few awkward sentences
* Swap the "replace" and "merge-extra" configuration settings
  explanations for better flow
* Consistent whitespace
* Update MergePlugin doc comment to reflect current functionality