### PR TITLE
Adjust logging of duplicate files

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -42,12 +42,28 @@ class Logger
     /**
      * Log a debug message
      *
+     * Messages will be output at the "very verbose" logging level (eg `-vv`
+     * needed on the Composer command).
+     *
+     * @param string $message
+     */
+    public function debug($message)
+    {
+        if ($this->inputOutput->isVeryVerbose()) {
+            $message = "  <info>[{$this->name}]</info> {$message}";
+            $this->log($message);
+        }
+    }
+
+    /**
+     * Log an informative message
+     *
      * Messages will be output at the "verbose" logging level (eg `-v` needed
      * on the Composer command).
      *
      * @param string $message
      */
-    public function debug($message)
+    public function info($message)
     {
         if ($this->inputOutput->isVerbose()) {
             $message = "  <info>[{$this->name}]</info> {$message}";

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -171,7 +171,7 @@ class ExtraPackage
             if (!isset($repoJson['type'])) {
                 continue;
             }
-            $this->logger->debug("Adding {$repoJson['type']} repository");
+            $this->logger->info("Adding {$repoJson['type']} repository");
             $repo = $repoManager->createRepository(
                 $repoJson['type'],
                 $repoJson
@@ -258,11 +258,11 @@ class ExtraPackage
     ) {
         foreach ($merge as $name => $link) {
             if (!isset($origin[$name]) || $replace) {
-                $this->logger->debug("Merging <comment>{$name}</comment>");
+                $this->logger->info("Merging <comment>{$name}</comment>");
                 $origin[$name] = $link;
             } else {
                 // Defer to solver.
-                $this->logger->debug(
+                $this->logger->info(
                     "Deferring duplicate <comment>{$name}</comment>"
                 );
                 $dups[] = $link;
@@ -455,7 +455,7 @@ class ExtraPackage
         } else {
             foreach ($extra as $key => $value) {
                 if (isset($rootExtra[$key])) {
-                    $this->logger->debug(
+                    $this->logger->info(
                         "Ignoring duplicate <comment>{$key}</comment> in ".
                         "<comment>{$this->path}</comment> extra config."
                     );

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -182,14 +182,12 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     protected function mergeFile(RootPackageInterface $root, $path)
     {
         if (isset($this->loadedFiles[$path])) {
-            $this->logger->debug(
-                "Skipping duplicate <comment>$path</comment>..."
-            );
+            $this->logger->debug("Already merged <comment>$path</comment>");
             return;
         } else {
             $this->loadedFiles[$path] = true;
         }
-        $this->logger->debug("Loading <comment>{$path}</comment>...");
+        $this->logger->info("Loading <comment>{$path}</comment>...");
 
         $package = new ExtraPackage($path, $this->composer, $this->logger);
         $package->mergeInto($root, $this->state);
@@ -211,14 +209,14 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     {
         $request = $event->getRequest();
         foreach ($this->state->getDuplicateLinks('require') as $link) {
-            $this->logger->debug(
+            $this->logger->info(
                 "Adding dependency <comment>{$link}</comment>"
             );
             $request->install($link->getTarget(), $link->getConstraint());
         }
         if ($this->state->isDevMode()) {
             foreach ($this->state->getDuplicateLinks('require-dev') as $link) {
-                $this->logger->debug(
+                $this->logger->info(
                     "Adding dev dependency <comment>{$link}</comment>"
                 );
                 $request->install($link->getTarget(), $link->getConstraint());
@@ -238,7 +236,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
         if ($op instanceof InstallOperation) {
             $package = $op->getPackage()->getName();
             if ($package === self::PACKAGE_NAME) {
-                $this->logger->debug('composer-merge-plugin installed');
+                $this->logger->info('composer-merge-plugin installed');
                 $this->state->setFirstInstall(true);
                 $this->state->setLocked(
                     $event->getComposer()->getLocker()->isLocked()
@@ -259,7 +257,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
         // @codeCoverageIgnoreStart
         if ($this->state->isFirstInstall()) {
             $this->state->setFirstInstall(false);
-            $this->logger->debug(
+            $this->logger->info(
                 '<comment>' .
                 'Running additional update to apply merge settings' .
                 '</comment>'

--- a/tests/phpunit/LoggerTest.php
+++ b/tests/phpunit/LoggerTest.php
@@ -19,11 +19,11 @@ use Prophecy\Argument;
 class LoggerTest extends \Prophecy\PhpUnit\ProphecyTestCase
 {
 
-    public function testVerboseDebug()
+    public function testVeryVerboseDebug()
     {
         $output = array();
         $io = $this->prophesize('Composer\IO\IOInterface');
-        $io->isVerbose()->willReturn(true)->shouldBeCalled();
+        $io->isVeryVerbose()->willReturn(true)->shouldBeCalled();
         $io->writeError(Argument::type('string'))->will(
             function ($args) use (&$output) {
                 $output[] = $args[0];
@@ -37,7 +37,37 @@ class LoggerTest extends \Prophecy\PhpUnit\ProphecyTestCase
         $this->assertContains('<info>[test]</info>', $output[0]);
     }
 
-    public function testNotVerboseDebug()
+    public function testNotVeryVerboseDebug()
+    {
+        $output = array();
+        $io = $this->prophesize('Composer\IO\IOInterface');
+        $io->isVeryVerbose()->willReturn(false)->shouldBeCalled();
+        $io->writeError(Argument::type('string'))->shouldNotBeCalled();
+        $io->write(Argument::type('string'))->shouldNotBeCalled();
+
+        $fixture = new Logger('test', $io->reveal());
+        $fixture->debug('foo');
+    }
+
+    public function testVerboseInfo()
+    {
+        $output = array();
+        $io = $this->prophesize('Composer\IO\IOInterface');
+        $io->isVerbose()->willReturn(true)->shouldBeCalled();
+        $io->writeError(Argument::type('string'))->will(
+            function ($args) use (&$output) {
+                $output[] = $args[0];
+            }
+        )->shouldBeCalled();
+        $io->write(Argument::type('string'))->shouldNotBeCalled();
+
+        $fixture = new Logger('test', $io->reveal());
+        $fixture->info('foo');
+        $this->assertEquals(1, count($output));
+        $this->assertContains('<info>[test]</info>', $output[0]);
+    }
+
+    public function testNotVerboseInfo()
     {
         $output = array();
         $io = $this->prophesize('Composer\IO\IOInterface');
@@ -46,7 +76,24 @@ class LoggerTest extends \Prophecy\PhpUnit\ProphecyTestCase
         $io->write(Argument::type('string'))->shouldNotBeCalled();
 
         $fixture = new Logger('test', $io->reveal());
-        $fixture->debug('foo');
+        $fixture->info('foo');
+    }
+
+    public function testWarning()
+    {
+        $output = array();
+        $io = $this->prophesize('Composer\IO\IOInterface');
+        $io->writeError(Argument::type('string'))->will(
+            function ($args) use (&$output) {
+                $output[] = $args[0];
+            }
+        )->shouldBeCalled();
+        $io->write(Argument::type('string'))->shouldNotBeCalled();
+
+        $fixture = new Logger('test', $io->reveal());
+        $fixture->warning('foo');
+        $this->assertEquals(1, count($output));
+        $this->assertContains('<error>[test]</error>', $output[0]);
     }
 }
 // vim:sw=4:ts=4:sts=4:et:


### PR DESCRIPTION
Only log duplicate files in VeryVerbose mode (`-vv`) and report the
files as "already merged" rather than "skipping duplicate" to reduce
confusion by end users.

Closes #66