### PR TITLE
Updating Travis CI and Scrutinizer yaml files.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,23 @@
+tools:
+    external_code_coverage:
+        timeout: 1200
+        runs: 5
+    php_analyzer: true
+    php_code_coverage: false
+    php_code_sniffer:
+        config:
+            standard: PSR2
+        filter:
+            paths: ['src','tests']
+    php_cpd:
+        enabled: true
+        excluded_dirs: ['vendor', 'tests', 'example']
+    php_loc:
+        enabled: true
+        excluded_dirs: ['vendor', 'tests', 'example']
+    php_pdepend: true
+    php_sim: true
+
 filter:
     excluded_paths:
         - 'tests/*'
@@ -35,24 +55,3 @@ checks:
         avoid_useless_overridden_methods: true
         avoid_conflicting_incrementers: true
         assignment_of_null_return: true
-        avoid_corrupting_byteorder_marks: true
-
-tools:
-    external_code_coverage:
-        timeout: 300
-        runs: 1
-    php_analyzer: true
-    php_code_coverage: false
-    php_code_sniffer:
-        config:
-            standard: PSR2
-        filter:
-            paths: ['src','tests']
-    php_cpd:
-        enabled: true
-        excluded_dirs: ['vendor', 'tests', 'example']
-    php_loc:
-        enabled: true
-        excluded_dirs: ['vendor', 'tests', 'example']
-    php_pdepend: true
-    php_sim: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,25 @@
 language: php
 
 php:
-  - "5.3.3"
-  - "5.3"
-  - "5.4"
-  - "5.5"
-  - "5.6"
-  - "7"
-  - "hhvm"
+  - 5.3.3
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
 
 sudo: false
 
-install: travis_retry composer install --no-interaction --prefer-source
+before_script:
+  - travis_retry composer self-update
+  - travis_retry composer install --prefer-source --no-interaction
 
 script: composer test
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover reports/coverage.xml
+  - if [ "$TRAVIS_PHP_VERSION" != "7.0" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "7.0" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover reports/coverage.xml; fi
 
 notifications:
   irc:


### PR DESCRIPTION
Update CI control files to exclude PHP7 and HHVM from coverage reporting
and adjust the time a job is expected to take and how many will report
coverage data.