### PR TITLE
Allow modern PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     "require-dev": {
         "composer/composer": "1.0.*@dev",
         "jakub-onderka/php-parallel-lint": "~0.8",
-        "phpspec/prophecy-phpunit": "~1.0",
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.8|~5.0",
         "squizlabs/php_codesniffer": "~2.1.0"
     },
     "autoload": {

--- a/tests/phpunit/LoggerTest.php
+++ b/tests/phpunit/LoggerTest.php
@@ -16,7 +16,7 @@ use Prophecy\Argument;
 /**
  * @covers Wikimedia\Composer\Logger
  */
-class LoggerTest extends \Prophecy\PhpUnit\ProphecyTestCase
+class LoggerTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testVerboseDebug()

--- a/tests/phpunit/Merge/PluginStateTest.php
+++ b/tests/phpunit/Merge/PluginStateTest.php
@@ -15,7 +15,7 @@ use Composer\Composer;
 /**
  * @covers Wikimedia\Composer\Merge\PluginState
  */
-class PluginStateTest extends \Prophecy\PhpUnit\ProphecyTestCase
+class PluginStateTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testLocked()

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -34,7 +34,7 @@ use ReflectionProperty;
  * @covers Wikimedia\Composer\Merge\PluginState
  * @covers Wikimedia\Composer\MergePlugin
  */
-class MergePluginTest extends \Prophecy\PhpUnit\ProphecyTestCase
+class MergePluginTest extends \PHPUnit_Framework_TestCase
 {
 
     /**


### PR DESCRIPTION
Bump PHPUnit versions to latest stable series. The double version number is for their PHP <= 5.5 and >= 5.6 branches.