### PR TITLE
Allow merging of *-dev sections to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Usage
             ],
             "recurse": true,
             "replace": false,
+            "merge-dev": true,
             "merge-extra": false
         }
     }
@@ -73,15 +74,17 @@ in the top-level composer.json file:
 
 * [autoload](https://getcomposer.org/doc/04-schema.md#autoload)
 * [autoload-dev](https://getcomposer.org/doc/04-schema.md#autoload-dev)
+  (optional, see [merge-dev](#merge-dev) below)
 * [conflict](https://getcomposer.org/doc/04-schema.md#conflict)
 * [provide](https://getcomposer.org/doc/04-schema.md#provide)
 * [replace](https://getcomposer.org/doc/04-schema.md#replace)
 * [repositories](https://getcomposer.org/doc/04-schema.md#repositories)
 * [require](https://getcomposer.org/doc/04-schema.md#require)
 * [require-dev](https://getcomposer.org/doc/04-schema.md#require-dev)
+  (optional, see [merge-dev](#merge-dev) below)
 * [suggest](https://getcomposer.org/doc/04-schema.md#suggest)
-* [extra](https://getcomposer.org/doc/04-schema.md#extra) (optional, see
-  [merge-extra](#merge-extra) below)
+* [extra](https://getcomposer.org/doc/04-schema.md#extra)
+  (optional, see [merge-extra](#merge-extra) below)
 
 
 ### recurse
@@ -100,6 +103,12 @@ version specified wins" conflict resolution strategy. In this mode, duplicate
 package declarations found in merged files will overwrite the declarations
 made by earlier files. Files are loaded in the order specified by the
 `include` setting with globbed files being processed in alphabetical order.
+
+
+### merge-dev
+
+By default, `autoload-dev` and `require-dev` sections of included files are
+merged. A `"merge-dev": false` setting will disable this behavior.
 
 
 ### merge-extra

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -136,7 +136,9 @@ class ExtraPackage
         $this->addRepositories($root);
 
         $this->mergeRequires('requires', $root, $state);
-        $this->mergeRequires('devRequires', $root, $state);
+        if ($state->isDevMode()) {
+            $this->mergeRequires('devRequires', $root, $state);
+        }
 
         $this->mergePackageLinks('conflicts', $root);
         $this->mergePackageLinks('replaces', $root);
@@ -145,7 +147,9 @@ class ExtraPackage
         $this->mergeSuggests($root);
 
         $this->mergeAutoload('autoload', $root);
-        $this->mergeAutoload('devAutoload', $root);
+        if ($state->isDevMode()) {
+            $this->mergeAutoload('devAutoload', $root);
+        }
 
         $this->mergeExtra($root, $state);
     }

--- a/src/Merge/PluginState.php
+++ b/src/Merge/PluginState.php
@@ -50,6 +50,12 @@ class PluginState
     protected $replace = false;
 
     /**
+     * Whether to merge the -dev sections.
+     * @var bool $mergeDev
+     */
+    protected $mergeDev = true;
+
+    /**
      * Whether to merge the extra section.
      *
      * By default, the extra section is not merged and there will be many
@@ -102,6 +108,7 @@ class PluginState
                 'include' => array(),
                 'recurse' => true,
                 'replace' => false,
+                'merge-dev' => true,
                 'merge-extra' => false,
             ),
             isset($extra['merge-plugin']) ? $extra['merge-plugin'] : array()
@@ -111,6 +118,7 @@ class PluginState
             $config['include'] : array($config['include']);
         $this->recurse = (bool)$config['recurse'];
         $this->replace = (bool)$config['replace'];
+        $this->mergeDev = (bool)$config['merge-dev'];
         $this->mergeExtra = (bool)$config['merge-extra'];
     }
 
@@ -191,7 +199,7 @@ class PluginState
      */
     public function isDevMode()
     {
-        return $this->devMode;
+        return $this->mergeDev && $this->devMode;
     }
 
     /**

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -811,6 +811,33 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
     }
 
+    /**
+     * Given a root package with merge-dev=false
+     *   and an include with require-dev and autoload-dev sections
+     * When the plugin is run
+     * Then the -dev sections are not merged
+     */
+    public function testMergeDevFalse()
+    {
+        $that = $this;
+        $dir = $this->fixtureDir(__FUNCTION__);
+
+        $root = $this->rootFromJson("{$dir}/composer.json");
+        $root->setRequires(Argument::type('array'))->will(
+            function ($args) use ($that) {
+                $requires = $args[0];
+                $that->assertEquals(2, count($requires));
+                $that->assertArrayHasKey('wikimedia/composer-merge-plugin', $requires);
+                $that->assertArrayHasKey('acme/foo', $requires);
+            }
+        )->shouldBeCalled();
+        $root->setDevRequires(Argument::type('array'))->shouldNotBeCalled();
+        $root->setRepositories(Argument::type('array'))->shouldNotBeCalled();
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+        $this->assertEquals(0, count($extraInstalls));
+    }
+
 
     /**
      * @param RootPackage $package

--- a/tests/phpunit/fixtures/testMergeDevFalse/composer.json
+++ b/tests/phpunit/fixtures/testMergeDevFalse/composer.json
@@ -1,0 +1,11 @@
+{
+    "require": {
+        "wikimedia/composer-merge-plugin": "dev-master"
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": "composer.local.json",
+            "merge-dev": false
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testMergeDevFalse/composer.local.json
+++ b/tests/phpunit/fixtures/testMergeDevFalse/composer.local.json
@@ -1,0 +1,11 @@
+{
+    "require": {
+        "acme/foo": "1.0.x-dev#abc123"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.8|~5.0"
+    },
+    "autoload-dev": {
+        "psr-4": { "Foo\\Tests\\": "tests/" }
+    }
+}


### PR DESCRIPTION
Add a new "merge-dev" configuration option that allows the root package
to disable processing of "autoload-dev" and "require-dev" sections of
merged files.

Closes #85