### PR TITLE
Feature/update self version

### DIFF
--- a/src/Merge/StabilityFlags.php
+++ b/src/Merge/StabilityFlags.php
@@ -109,7 +109,7 @@ class StabilityFlags
         }
 
         // Filter out null stability values
-        return array_filter($flags, function($v) {
+        return array_filter($flags, function ($v) {
             return $v !== null;
         });
     }

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -208,14 +208,14 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     public function onDependencySolve(InstallerEvent $event)
     {
         $request = $event->getRequest();
-        foreach ($this->state->getDuplicateLinks('requires') as $link) {
+        foreach ($this->state->getDuplicateLinks('require') as $link) {
             $this->logger->info(
                 "Adding dependency <comment>{$link}</comment>"
             );
             $request->install($link->getTarget(), $link->getConstraint());
         }
         if ($this->state->isDevMode()) {
-            foreach ($this->state->getDuplicateLinks('devRequires') as $link) {
+            foreach ($this->state->getDuplicateLinks('require-dev') as $link) {
                 $this->logger->info(
                     "Adding dev dependency <comment>{$link}</comment>"
                 );

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -1044,52 +1044,52 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
     {
         $alias = $this->prophesize('Composer\Package\RootAliasPackage');
         $alias->getAliasOf()->willReturn($root);
-        $alias->getVersion()->will(function() use ($root) {
+        $alias->getVersion()->will(function () use ($root) {
             return $root->getVersion();
         });
-        $alias->getPrettyVersion()->will(function() use ($root) {
+        $alias->getPrettyVersion()->will(function () use ($root) {
             return $root->getPrettyVersion();
         });
-        $alias->getMinimumStability()->will(function() use ($root) {
+        $alias->getMinimumStability()->will(function () use ($root) {
             return $root->getMinimumStability();
         });
-        $alias->getAliases()->will(function() use ($root) {
+        $alias->getAliases()->will(function () use ($root) {
             return $root->getAliases();
         });
-        $alias->getAutoload()->will(function() use ($root) {
+        $alias->getAutoload()->will(function () use ($root) {
             return $root->getAutoload();
         });
-        $alias->getConflicts()->will(function() use ($root) {
+        $alias->getConflicts()->will(function () use ($root) {
             return $root->getConflicts();
         });
-        $alias->getDevAutoload()->will(function() use ($root) {
+        $alias->getDevAutoload()->will(function () use ($root) {
             return $root->getDevAutoload();
         });
-        $alias->getDevRequires()->will(function() use ($root) {
+        $alias->getDevRequires()->will(function () use ($root) {
             return $root->getDevRequires();
         });
-        $alias->getExtra()->will(function() use ($root) {
+        $alias->getExtra()->will(function () use ($root) {
             return $root->getExtra();
         });
-        $alias->getProvides()->will(function() use ($root) {
+        $alias->getProvides()->will(function () use ($root) {
             return $root->getProvides();
         });
-        $alias->getReferences()->will(function() use ($root) {
+        $alias->getReferences()->will(function () use ($root) {
             return $root->getReferences();
         });
-        $alias->getReplaces()->will(function() use ($root) {
+        $alias->getReplaces()->will(function () use ($root) {
             return $root->getReplaces();
         });
-        $alias->getRepositories()->will(function() use ($root) {
+        $alias->getRepositories()->will(function () use ($root) {
             return $root->getRepositories();
         });
-        $alias->getRequires()->will(function() use ($root) {
+        $alias->getRequires()->will(function () use ($root) {
             return $root->getRequires();
         });
-        $alias->getStabilityFlags()->will(function() use ($root) {
+        $alias->getStabilityFlags()->will(function () use ($root) {
             return $root->getStabilityFlags();
         });
-        $alias->getSuggests()->will(function() use ($root) {
+        $alias->getSuggests()->will(function () use ($root) {
             return $root->getSuggests();
         });
         return $alias;

--- a/tests/phpunit/fixtures/testSelfVersion/composer.json
+++ b/tests/phpunit/fixtures/testSelfVersion/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "foo/root",
+    "version": "1.2.3.4",
+    "replace": {
+      "foo/bar": "self.version"
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": "composer.local.json"
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testSelfVersion/composer.local.json
+++ b/tests/phpunit/fixtures/testSelfVersion/composer.local.json
@@ -1,0 +1,6 @@
+{
+  "replace": {
+    "foo/baz": "self.version",
+    "foo/xyzzy": "~1.0"
+  }
+}


### PR DESCRIPTION
Properly expand self.version references in package links to reference
the current root package version.

Fixing "self.version" was suggested by @webflo in pull request #73. The
implementation provided there only dealt with "replace" links and relied
on the root package having the same source package.

Closes #88