### PR TITLE
Add support for required files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Usage
                 "composer.local.json",
                 "extensions/*/composer.json"
             ],
+            "require": [
+                "submodule/composer.json"
+            ],
             "recurse": true,
             "replace": false,
             "merge-dev": true,
@@ -86,6 +89,11 @@ in the top-level composer.json file:
 * [extra](https://getcomposer.org/doc/04-schema.md#extra)
   (optional, see [merge-extra](#merge-extra) below)
 
+
+### require
+
+The `require` setting is identical to `[include](#include)` except when
+a pattern fails to match at least one file then it will cause an error.
 
 ### recurse
 

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -84,6 +84,17 @@ class ExtraPackage
     }
 
     /**
+     * Get list of additional packages to require if precessing recursively.
+     *
+     * @return array
+     */
+    public function getRequires()
+    {
+        return isset($this->json['extra']['merge-plugin']['require']) ?
+            $this->json['extra']['merge-plugin']['require'] : array();
+    }
+
+    /**
      * Read the contents of a composer.json style file into an array.
      *
      * The package contents are fixed up to be usable to create a Package

--- a/src/Merge/MissingFileException.php
+++ b/src/Merge/MissingFileException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * This file is part of the Composer Merge plugin.
+ *
+ * Copyright (C) 2015 Bryan Davis, Wikimedia Foundation, and contributors
+ *
+ * This software may be modified and distributed under the terms of the MIT
+ * license. See the LICENSE file for details.
+ */
+
+namespace Wikimedia\Composer\Merge;
+
+/**
+ * @author Bryan Davis <bd808@bd808.com>
+ */
+class MissingFileException extends \RuntimeException
+{
+}

--- a/src/Merge/PluginState.php
+++ b/src/Merge/PluginState.php
@@ -30,6 +30,11 @@ class PluginState
     protected $includes = array();
 
     /**
+     * @var array $requires
+     */
+    protected $requires = array();
+
+    /**
      * @var array $duplicateLinks
      */
     protected $duplicateLinks = array();
@@ -106,6 +111,7 @@ class PluginState
         $config = array_merge(
             array(
                 'include' => array(),
+                'require' => array(),
                 'recurse' => true,
                 'replace' => false,
                 'merge-dev' => true,
@@ -116,6 +122,8 @@ class PluginState
 
         $this->includes = (is_array($config['include'])) ?
             $config['include'] : array($config['include']);
+        $this->requires = (is_array($config['require'])) ?
+            $config['require'] : array($config['require']);
         $this->recurse = (bool)$config['recurse'];
         $this->replace = (bool)$config['replace'];
         $this->mergeDev = (bool)$config['merge-dev'];
@@ -130,6 +138,16 @@ class PluginState
     public function getIncludes()
     {
         return $this->includes;
+    }
+
+    /**
+     * Get list of filenames and/or glob patterns to require
+     *
+     * @return array
+     */
+    public function getRequires()
+    {
+        return $this->requires;
     }
 
     /**

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -188,7 +188,6 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
     }
 
 
-
     /**
      * Given a root package with no requires
      *   and a composer.local.json with one require, which includes a composer.local.2.json
@@ -225,6 +224,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($extraInstalls));
     }
 
+
     /**
      * Given a root package with no requires that disables recursion
      *   and a composer.local.json with one require, which includes a composer.local.2.json
@@ -260,6 +260,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(0, count($extraInstalls));
     }
+
 
     /**
      * Given a root package with requires
@@ -310,6 +311,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('monolog/monolog', $extraInstalls[0][0]);
         $this->assertEquals('foo', $extraInstalls[1][0]);
     }
+
 
     /**
      * Given a root package
@@ -391,6 +393,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($extraInstalls));
     }
 
+
     /**
      * Given a root package
      *   and a composer.local.json with required packages
@@ -448,6 +451,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(0, count($extraInstalls));
     }
+
 
     public function testMergedAutoload()
     {
@@ -528,6 +532,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+
     /**
      * Given a root package with an extra section
      *   and a composer.local.json with an extra section with no conflicting keys
@@ -564,6 +569,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($extraInstalls));
     }
 
+
     /**
      * Given a root package with an extra section
      *   and a composer.local.json with an extra section with a conflicting key
@@ -599,6 +605,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(0, count($extraInstalls));
     }
+
 
     /**
      * Given a root package with an extra section
@@ -637,6 +644,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($extraInstalls));
     }
 
+
     /**
      * @dataProvider provideOnPostPackageInstall
      * @param string $package Package installed
@@ -665,6 +673,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($locked, $this->getState()->isLocked());
     }
 
+
     public function provideOnPostPackageInstall()
     {
         return array(
@@ -673,6 +682,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
             array('foo/bar', false, false),
         );
     }
+
 
     /**
      * Given a root package with a branch alias
@@ -768,6 +778,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
     }
 
+
     /**
      * Test replace link with self.version as version constraint.
      */
@@ -856,6 +867,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
     }
 
+
     /**
      * Given a root package with merge-dev=false
      *   and an include with require-dev and autoload-dev sections
@@ -880,6 +892,39 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $root->setRepositories(Argument::type('array'))->shouldNotBeCalled();
 
         $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+        $this->assertEquals(0, count($extraInstalls));
+    }
+
+
+    /**
+     * @expectedException \Wikimedia\Composer\Merge\MissingFileException
+     */
+    public function testMissingRequireThrowsException()
+    {
+        $dir = $this->fixtureDir(__FUNCTION__);
+        $root = $this->rootFromJson("{$dir}/composer.json");
+        $root->getRequires()->shouldNotBeCalled();
+        $this->triggerPlugin($root->reveal(), $dir);
+    }
+
+
+    public function testRequire()
+    {
+        $that = $this;
+        $dir = $this->fixtureDir(__FUNCTION__);
+
+        $root = $this->rootFromJson("{$dir}/composer.json");
+
+        $root->setRequires(Argument::type('array'))->will(
+            function ($args) use ($that) {
+                $requires = $args[0];
+                $that->assertEquals(1, count($requires));
+                $that->assertArrayHasKey('monolog/monolog', $requires);
+            }
+        );
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+
         $this->assertEquals(0, count($extraInstalls));
     }
 

--- a/tests/phpunit/fixtures/testMissingRequireThrowsException/composer.json
+++ b/tests/phpunit/fixtures/testMissingRequireThrowsException/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "wikimedia/composer-merge-plugin": "dev-master"
+    },
+    "extra": {
+        "merge-plugin": {
+            "require": "glob/*.json"
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRequire/composer.json
+++ b/tests/phpunit/fixtures/testRequire/composer.json
@@ -1,0 +1,7 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "require": "composer.local.json"
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRequire/composer.local.json
+++ b/tests/phpunit/fixtures/testRequire/composer.local.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "monolog/monolog": "^1.0"
+    }
+}


### PR DESCRIPTION
The `require` setting functions the same as the `include` setting but
raises an exception when any pattern supplied fails to match any files.

Closes #37