### PR TITLE
Add ability to merge remote composer configurations via http

### DIFF
--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -22,6 +22,8 @@ use Composer\Package\RootAliasPackage;
 use Composer\Package\RootPackage;
 use Composer\Package\RootPackageInterface;
 use Composer\Package\Version\VersionParser;
+use Composer\IO\IOInterface;
+use Composer\Util\RemoteFilesystem;
 use UnexpectedValueException;
 
 /**
@@ -44,6 +46,11 @@ class ExtraPackage
     protected $logger;
 
     /**
+     * @var IOInterface $io
+     */
+    protected $io;
+
+    /**
      * @var string $path
      */
     protected $path;
@@ -63,11 +70,12 @@ class ExtraPackage
      * @param Composer $composer
      * @param Logger $logger
      */
-    public function __construct($path, Composer $composer, Logger $logger)
+    public function __construct($path, Composer $composer, Logger $logger, IOInterface $io)
     {
         $this->path = $path;
         $this->composer = $composer;
         $this->logger = $logger;
+        $this->io = $io;
         $this->json = $this->readPackageJson($path);
         $this->package = $this->loadPackage($this->json);
     }
@@ -107,7 +115,12 @@ class ExtraPackage
      */
     protected function readPackageJson($path)
     {
-        $file = new JsonFile($path);
+        if(substr($path, 0, 4) === 'http'){
+            $file = new JsonFile($path, new RemoteFilesystem($this->io));
+        }else{
+            $file = new JsonFile($path);
+        }
+        
         $json = $file->read();
         if (!isset($json['name'])) {
             $json['name'] = 'merge-plugin/' .

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -102,6 +102,11 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     protected $logger;
 
     /**
+     * @var IOInterface $io
+     */
+    protected $io;
+
+    /**
      * Files that have already been processed
      *
      * @var string[] $loadedFiles
@@ -115,6 +120,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     {
         $this->composer = $composer;
         $this->state = new PluginState($this->composer);
+        $this->io = $io;
         $this->logger = new Logger('merge-plugin', $io);
     }
 
@@ -179,12 +185,25 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
                 }
                 return $files;
             },
-            array_map('glob', $patterns),
+            array_map(array($this, 'validatePath'), $patterns),
             $patterns
         );
 
         foreach (array_reduce($files, 'array_merge', array()) as $path) {
             $this->mergeFile($root, $path);
+        }
+    }
+
+    protected function validatePath($path){
+        if(substr($path, 0, 4) === 'http'){
+            $headers = get_headers ( $path );
+            $valid = array();
+            if ( preg_match('#^HTTP/.*\s+[(200|301|302|307|308)]+\s#i', $headers[0]) ){
+                $valid[] = $path;
+            }
+            return $valid;
+        }else{
+            return glob($path);
         }
     }
 
@@ -204,7 +223,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
         }
         $this->logger->info("Loading <comment>{$path}</comment>...");
 
-        $package = new ExtraPackage($path, $this->composer, $this->logger);
+        $package = new ExtraPackage($path, $this->composer, $this->logger, $this->io);
         $package->mergeInto($root, $this->state);
 
         if ($this->state->recurseIncludes()) {

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -928,6 +928,26 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($extraInstalls));
     }
 
+    public function testRequireRemote()
+    {
+        $that = $this;
+        $dir = $this->fixtureDir(__FUNCTION__);
+
+        $root = $this->rootFromJson("{$dir}/composer.json");
+
+        $root->setRequires(Argument::type('array'))->will(
+            function ($args) use ($that) {
+                $requires = $args[0];
+                $that->assertEquals(1, count($requires));
+                $that->assertArrayHasKey('monolog/monolog', $requires);
+            }
+        );
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+
+        $this->assertEquals(0, count($extraInstalls));
+    }
+
 
     /**
      * @param RootPackage $package

--- a/tests/phpunit/fixtures/testRequireRemote/composer.json
+++ b/tests/phpunit/fixtures/testRequireRemote/composer.json
@@ -1,0 +1,7 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "require": "https://raw.githubusercontent.com/wikimedia/composer-merge-plugin/master/example/composer.local.json"
+        }
+    }
+}


### PR DESCRIPTION
I needed to pull a centralized list of required packages into multiple composer configs. Since composer has the ability to read JSON contents from a remote source via HTTP it was a straight forward change to composer-merge-plugin to correctly validate that the url exists (but still use glob for local files) and pass a RemoteFileSystem object to JsonFile constructor if we're dealing with a URL.
