### PR TITLE
Resolve the self.version contraint through packages from the root package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo: false
 
 before_script:
   - travis_retry composer self-update
-  - if [ "$TRAVIS_PHP_VERSION" == "5.3.3" ]; then composer config disable-tls true; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "5.3.3" ]; then composer config disable-tls true; composer config secure-http false; fi
   - travis_retry composer install --prefer-source --no-interaction
 
 script: composer test

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -440,9 +440,24 @@ class ExtraPackage
         $prettyVersion = $root->getPrettyVersion();
         $vp = new VersionParser();
 
+        $method = 'get' . ucfirst($linkType['method']);
+        $packages = $root->$method();
+
         return array_map(
-            function ($link) use ($linkType, $version, $prettyVersion, $vp) {
+            function ($link) use ($linkType, $version, $prettyVersion, $vp, $packages) {
                 if ('self.version' === $link->getPrettyConstraint()) {
+                    if (isset($packages[$link->getSource()])) {
+                        /** @var Link $package */
+                        $package = $packages[$link->getSource()];
+                        return new Link(
+                            $link->getSource(),
+                            $link->getTarget(),
+                            $vp->parseConstraints($package->getConstraint()->getPrettyString()),
+                            $linkType['description'],
+                            $package->getPrettyConstraint()
+                        );
+                    }
+
                     return new Link(
                         $link->getSource(),
                         $link->getTarget(),

--- a/tests/phpunit/fixtures/testSelfVersionNoRootVersion/composer.json
+++ b/tests/phpunit/fixtures/testSelfVersionNoRootVersion/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "foo/root",
+    "replace": {
+      "foo/bar": "~8.0"
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": "composer.local.json"
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testSelfVersionNoRootVersion/composer.local.json
+++ b/tests/phpunit/fixtures/testSelfVersionNoRootVersion/composer.local.json
@@ -1,0 +1,7 @@
+{
+  "name": "foo/bar",
+  "replace": {
+    "foo/baz": "self.version",
+    "foo/xyzzy": "~1.0"
+  }
+}


### PR DESCRIPTION
``foo/baz`` should resolve to ``~8.0`` because the root composer.json requires ``~8.0.``