### PR TITLE
Fix unit tests for Composer upstream changes

### DIFF
--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -351,12 +351,14 @@ class ExtraPackage
         $links = $this->package->{$getter}();
         if (!empty($links)) {
             $unwrapped = self::unwrapIfNeeded($root, $setter);
+            // @codeCoverageIgnoreStart
             if ($root !== $unwrapped) {
                 $this->logger->warning(
                     'This Composer version does not support ' .
                     "'{$type}' merging for aliased packages."
                 );
             }
+            // @codeCoverageIgnoreEnd
             $unwrapped->{$setter}(array_merge(
                 $root->{$getter}(),
                 $this->replaceSelfVersionDependencies($type, $links, $root)
@@ -476,12 +478,14 @@ class ExtraPackage
         RootPackageInterface $root,
         $method = 'setExtra'
     ) {
+        // @codeCoverageIgnoreStart
         if ($root instanceof RootAliasPackage &&
             !method_exists($root, $method)
         ) {
             // Unwrap and return the aliased RootPackage.
             $root = $root->getAliasOf();
         }
+        // @codeCoverageIgnoreEnd
         return $root;
     }
 }

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -695,6 +695,13 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $io = $this->io;
         $dir = $this->fixtureDir(__FUNCTION__);
 
+        // RootAliasPackage was updated in 06c44ce to include more setters
+        // that we take advantage of if available
+        $haveComposerWithCompleteRootAlias = method_exists(
+            'Composer\Package\RootPackageInterface',
+            'setRepositories'
+        );
+
         $repoManager = $this->prophesize(
             'Composer\Repository\RepositoryManager'
         );
@@ -716,24 +723,40 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         );
 
         $root = $this->rootFromJson("{$dir}/composer.json");
-        // Handled by alias
+
+        // Always handled by alias
         $root->setDevRequires(Argument::type('array'))->shouldNotBeCalled();
         $root->setRequires(Argument::type('array'))->shouldNotBeCalled();
 
-        // Handled unwrapped
-        $root->setAutoload(Argument::type('array'))->shouldBeCalled();
-        $root->setConflicts(Argument::type('array'))->shouldBeCalled();
-        $root->setDevAutoload(Argument::type('array'))->shouldBeCalled();
-        $root->setProvides(Argument::type('array'))->shouldBeCalled();
-        $root->setReplaces(Argument::type('array'))->shouldBeCalled();
-        $root->setRepositories(Argument::type('array'))->shouldBeCalled();
-        $root->setSuggests(Argument::type('array'))->shouldBeCalled();
-
         $alias = $this->makeAliasFor($root->reveal());
-        $alias->getAliasOf()->shouldBeCalled();
         $alias->getExtra()->shouldBeCalled();
         $alias->setDevRequires(Argument::type('array'))->shouldBeCalled();
         $alias->setRequires(Argument::type('array'))->shouldBeCalled();
+
+        if ($haveComposerWithCompleteRootAlias) {
+            // When Composer supports it we will apply our changes directly to
+            // the RootAliasPackage
+            $alias->setAutoload(Argument::type('array'))->shouldBeCalled();
+            $alias->setConflicts(Argument::type('array'))->shouldBeCalled();
+            $alias->setDevAutoload(Argument::type('array'))->shouldBeCalled();
+            $alias->setProvides(Argument::type('array'))->shouldBeCalled();
+            $alias->setReplaces(Argument::type('array'))->shouldBeCalled();
+            $alias->setRepositories(Argument::type('array'))->shouldBeCalled();
+            $alias->setStabilityFlags(Argument::type('array'))->shouldBeCalled();
+            $alias->setSuggests(Argument::type('array'))->shouldBeCalled();
+        } else {
+            // With older versions of Composer we will fall back to unwrapping
+            // the aliased RootPackage and make calls to it
+            $root->setAutoload(Argument::type('array'))->shouldBeCalled();
+            $root->setConflicts(Argument::type('array'))->shouldBeCalled();
+            $root->setDevAutoload(Argument::type('array'))->shouldBeCalled();
+            $root->setProvides(Argument::type('array'))->shouldBeCalled();
+            $root->setReplaces(Argument::type('array'))->shouldBeCalled();
+            $root->setRepositories(Argument::type('array'))->shouldBeCalled();
+            $root->setSuggests(Argument::type('array'))->shouldBeCalled();
+            $alias->getAliasOf()->shouldBeCalled();
+        }
+
         $alias = $alias->reveal();
 
         $this->triggerPlugin($alias, $dir);


### PR DESCRIPTION
Summary:
Composer was changed in https://github.com/composer/composer/pull/4542
to provide a full interface for RootAliasPackage so that we no longer
need to try and unwrap the aliased package. Update the unit tests to
detect the Composer version in use by looking for
a RootAliasPackage::setRepositories() method and adjust mock
expectations accordingly.

Test Plan:
Run `composer test` with old version of Composer (eg 1.0.0-alpha10) and
newer version (eg 1.0.0-alpha11).

Reviewers: Legoktm

Differential Revision: https://phabricator.wikimedia.org/D63