### PR TITLE
TravisCI: Disable Composer TLS for PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,21 @@ php:
 
 sudo: false
 
+env:
+  global:
+    - COMPOSER_DISABLE_XDEBUG_WARN=1
+
 before_script:
-  - travis_retry composer self-update
-  - if [ "$TRAVIS_PHP_VERSION" == "5.3.3" ]; then composer config disable-tls true; composer config secure-http false; fi
+  - [ "$TRAVIS_PHP_VERSION" = "5.3.3" ] && composer config disable-tls true
+  - [ "$TRAVIS_PHP_VERSION" = "5.3.3" ] && composer config secure-http false
+  - [ "$TRAVIS_PHP_VERSION" != "5.3.3" ] && travis_retry composer self-update
   - travis_retry composer install --prefer-source --no-interaction
 
 script: composer test
 
 after_script:
-  - if [ "$TRAVIS_PHP_VERSION" != "7.0" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ "$TRAVIS_PHP_VERSION" != "7.0" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover reports/coverage.xml; fi
+  - [ "$TRAVIS_PHP_VERSION" != "7.0" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && wget https://scrutinizer-ci.com/ocular.phar
+  - [ "$TRAVIS_PHP_VERSION" != "7.0" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && php ocular.phar code-coverage:upload --format=php-clover reports/coverage.xml
 
 notifications:
   irc:


### PR DESCRIPTION
Follow up to 1000cdb that disables the TLS handling for Composer before
trying to do anything else. The base Composer version at Travis is now
new enough that self-update fails on 5.3 when TLS is left enabled.