### PR TITLE
Support for composer PluginEvents::INIT event.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "composer-plugin-api": "^1.1",
+        "composer-plugin-api": "^1.0",
         "php": ">=5.3.2"
     },
     "require-dev": {
-        "composer/composer": "^1.1",
+        "composer/composer": "1.0.*@dev",
         "jakub-onderka/php-parallel-lint": "~0.8",
         "phpunit/phpunit": "~4.8|~5.0",
         "squizlabs/php_codesniffer": "~2.1.0"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.2"
     },
     "require-dev": {
-        "composer/composer": "^1.1@dev",
+        "composer/composer": "^1.1",
         "jakub-onderka/php-parallel-lint": "~0.8",
         "phpunit/phpunit": "~4.8|~5.0",
         "squizlabs/php_codesniffer": "~2.1.0"

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "composer-plugin-api": "^1.0",
+        "composer-plugin-api": "^1.1",
         "php": ">=5.3.2"
     },
     "require-dev": {
-        "composer/composer": "1.0.*@dev",
+        "composer/composer": "^1.1@dev",
         "jakub-onderka/php-parallel-lint": "~0.8",
         "phpunit/phpunit": "~4.8|~5.0",
         "squizlabs/php_codesniffer": "~2.1.0"

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -175,6 +175,19 @@ class ExtraPackage
     }
 
     /**
+     * Merge just the dev portion into a RootPackageInterface
+     *
+     * @param RootPackageInterface $root
+     * @param PluginState $state
+     */
+    public function mergeDev(RootPackageInterface $root, PluginState $state)
+    {
+        $this->mergeRequires('require-dev', $root, $state);
+        $this->mergeAutoload('devAutoload', $root);
+        $this->mergeReferences($root);
+    }
+
+    /**
      * Add a collection of repositories described by the given configuration
      * to the given package and the global repository manager.
      *

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -235,14 +235,14 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             return;
         }
 
-        $this->logger->info("Loading <comment>{$path}</comment>...");
-
         $package = new ExtraPackage($path, $this->composer, $this->logger);
 
         // If something was already loaded, merge just the dev section.
         if (isset($this->partiallyLoadedFiles[$path])) {
+            $this->logger->info("Loading -dev sections of <comment>{$path}</comment>...");
             $package->mergeDev($root, $this->state);
         } else {
+            $this->logger->info("Loading <comment>{$path}</comment>...");
             $package->mergeInto($root, $this->state);
         }
 

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -26,7 +26,6 @@ use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
 use Composer\Package\RootPackageInterface;
 use Composer\Plugin\PluginInterface;
-use Composer\Plugin\PluginEvents;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 
@@ -88,6 +87,11 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     const PACKAGE_NAME = 'wikimedia/composer-merge-plugin';
 
     /**
+     * Name of the composer 1.1 init event.
+     */
+    const INIT = 'init';
+
+    /**
      * @var Composer $composer
      */
     protected $composer;
@@ -125,7 +129,10 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            PluginEvents::INIT => 'onInit',
+            // Use our own constant to make this event optional. Once
+            // composer-1.1 is required, this can use PluginEvents::INIT
+            // instead.
+            self::INIT => 'onInit',
             InstallerEvents::PRE_DEPENDENCIES_SOLVING => 'onDependencySolve',
             PackageEvents::POST_PACKAGE_INSTALL => 'onPostPackageInstall',
             ScriptEvents::POST_INSTALL_CMD => 'onPostInstallOrUpdate',

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -26,6 +26,7 @@ use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
 use Composer\Package\RootPackageInterface;
 use Composer\Plugin\PluginInterface;
+use Composer\Plugin\PluginEvents;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 
@@ -124,6 +125,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
+            PluginEvents::INIT => 'onInit',
             InstallerEvents::PRE_DEPENDENCIES_SOLVING => 'onDependencySolve',
             PackageEvents::POST_PACKAGE_INSTALL => 'onPostPackageInstall',
             ScriptEvents::POST_INSTALL_CMD => 'onPostInstallOrUpdate',
@@ -132,6 +134,21 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             ScriptEvents::PRE_INSTALL_CMD => 'onInstallUpdateOrDump',
             ScriptEvents::PRE_UPDATE_CMD => 'onInstallUpdateOrDump',
         );
+    }
+
+    /**
+     * Handle an event callback for initialization.
+     *
+     * @param \Composer\EventDispatcher\Event $event
+     */
+    public function onInit(\Composer\EventDispatcher\Event $event)
+    {
+        $this->state->loadSettings();
+        // @todo devMode cannot be properly detected at this stage, but
+        //       merging it should not hurt.
+        $this->state->setDevMode(true);
+        $this->mergeFiles($this->state->getIncludes(), false);
+        $this->mergeFiles($this->state->getRequires(), true);
     }
 
     /**

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -16,6 +16,7 @@ use Wikimedia\Composer\Merge\PluginState;
 
 use Composer\Composer;
 use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\EventDispatcher\Event as BaseEvent;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Factory;
 use Composer\Installer;
@@ -26,7 +27,7 @@ use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
 use Composer\Package\RootPackageInterface;
 use Composer\Plugin\PluginInterface;
-use Composer\Script\Event;
+use Composer\Script\Event as ScriptEvent;
 use Composer\Script\ScriptEvents;
 
 /**
@@ -89,7 +90,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     /**
      * Name of the composer 1.1 init event.
      */
-    const INIT = 'init';
+    const COMPAT_PLUGINEVENTS_INIT = 'init';
 
     /**
      * @var Composer $composer
@@ -107,11 +108,18 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
     protected $logger;
 
     /**
-     * Files that have already been processed
+     * Files that have already been fully processed
      *
      * @var string[] $loadedFiles
      */
     protected $loadedFiles = array();
+
+    /**
+     * Files that have already been partially processed
+     *
+     * @var string[] $partiallyLoadedFiles
+     */
+    protected $partiallyLoadedFiles = array();
 
     /**
      * {@inheritdoc}
@@ -132,7 +140,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             // Use our own constant to make this event optional. Once
             // composer-1.1 is required, this can use PluginEvents::INIT
             // instead.
-            self::INIT => 'onInit',
+            self::COMPAT_PLUGINEVENTS_INIT => 'onInit',
             InstallerEvents::PRE_DEPENDENCIES_SOLVING => 'onDependencySolve',
             PackageEvents::POST_PACKAGE_INSTALL => 'onPostPackageInstall',
             ScriptEvents::POST_INSTALL_CMD => 'onPostInstallOrUpdate',
@@ -148,12 +156,13 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
      *
      * @param \Composer\EventDispatcher\Event $event
      */
-    public function onInit(\Composer\EventDispatcher\Event $event)
+    public function onInit(BaseEvent $event)
     {
         $this->state->loadSettings();
-        // @todo devMode cannot be properly detected at this stage, but
-        //       merging it should not hurt.
-        $this->state->setDevMode(true);
+        // It is not possible to know if the user specified --dev or --no-dev
+        // so assume it is false. The dev section will be merged later when
+        // the other events fire.
+        $this->state->setDevMode(false);
         $this->mergeFiles($this->state->getIncludes(), false);
         $this->mergeFiles($this->state->getRequires(), true);
     }
@@ -163,9 +172,9 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
      * checking for "merge-plugin" in the "extra" data and merging package
      * contents if found.
      *
-     * @param Event $event
+     * @param ScriptEvent $event
      */
-    public function onInstallUpdateOrDump(Event $event)
+    public function onInstallUpdateOrDump(ScriptEvent $event)
     {
         $this->state->loadSettings();
         $this->state->setDevMode($event->isDevMode());
@@ -220,16 +229,28 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
      */
     protected function mergeFile(RootPackageInterface $root, $path)
     {
-        if (isset($this->loadedFiles[$path])) {
-            $this->logger->debug("Already merged <comment>$path</comment>");
+        if (isset($this->loadedFiles[$path]) ||
+            (isset($this->partiallyLoadedFiles[$path]) && !$this->state->isDevMode())) {
+            $this->logger->debug("Already merged <comment>$path</comment> completely");
             return;
-        } else {
-            $this->loadedFiles[$path] = true;
         }
+
         $this->logger->info("Loading <comment>{$path}</comment>...");
 
         $package = new ExtraPackage($path, $this->composer, $this->logger);
-        $package->mergeInto($root, $this->state);
+
+        // If something was already loaded, merge just the dev section.
+        if (isset($this->partiallyLoadedFiles[$path])) {
+            $package->mergeDev($root, $this->state);
+        } else {
+            $package->mergeInto($root, $this->state);
+        }
+
+        if ($this->state->isDevMode()) {
+            $this->loadedFiles[$path] = true;
+        } else {
+            $this->partiallyLoadedFiles[$path] = true;
+        }
 
         if ($this->state->recurseIncludes()) {
             $this->mergeFiles($package->getIncludes(), false);
@@ -290,9 +311,9 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
      * plugin was installed during the run then trigger an update command to
      * process any merge-patterns in the current config.
      *
-     * @param Event $event
+     * @param ScriptEvent $event
      */
-    public function onPostInstallOrUpdate(Event $event)
+    public function onPostInstallOrUpdate(ScriptEvent $event)
     {
         // @codeCoverageIgnoreStart
         if ($this->state->isFirstInstall()) {

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -77,7 +77,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
             InstallerEvents::PRE_DEPENDENCIES_SOLVING,
             $subscriptions
         );
-        $this->assertArrayHasKey(PluginEvents::INIT, $subscriptions);
+        $this->assertArrayHasKey(MergePlugin::INIT, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_INSTALL_CMD, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_UPDATE_CMD, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_AUTOLOAD_DUMP, $subscriptions);
@@ -1029,7 +1029,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $this->composer->getPackage()->willReturn($package);
 
         $event = new \Composer\EventDispatcher\Event(
-            PluginEvents::INIT
+            MergePlugin::INIT
         );
         $this->fixture->onInit($event);
 

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -77,7 +77,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
             InstallerEvents::PRE_DEPENDENCIES_SOLVING,
             $subscriptions
         );
-        $this->assertArrayHasKey(MergePlugin::INIT, $subscriptions);
+        $this->assertArrayHasKey(MergePlugin::COMPAT_PLUGINEVENTS_INIT, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_INSTALL_CMD, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_UPDATE_CMD, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_AUTOLOAD_DUMP, $subscriptions);
@@ -308,6 +308,13 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($extraInstalls));
         $this->assertEquals('monolog/monolog', $extraInstalls[0][0]);
         $this->assertEquals('foo', $extraInstalls[1][0]);
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir, true);
+
+        $this->assertEquals(2, count($extraInstalls));
+        $this->assertEquals('monolog/monolog', $extraInstalls[0][0]);
+        $this->assertEquals('foo', $extraInstalls[1][0]);
+
     }
 
 
@@ -388,6 +395,10 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
 
         $this->assertEquals(0, count($extraInstalls));
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir, true);
+
+        $this->assertEquals(0, count($extraInstalls));
     }
 
 
@@ -444,6 +455,10 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $root->setSuggests(Argument::any())->shouldNotBeCalled();
 
         $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+
+        $this->assertEquals(0, count($extraInstalls));
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir, true);
 
         $this->assertEquals(0, count($extraInstalls));
     }
@@ -749,6 +764,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $alias = $alias->reveal();
 
         $this->triggerPlugin($alias, $dir);
+        $this->triggerPlugin($alias, $dir, true);
     }
 
 
@@ -944,6 +960,10 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
 
         $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
         $this->assertEquals(0, count($extraInstalls));
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir, true);
+        $this->assertEquals(0, count($extraInstalls));
+
     }
 
 
@@ -1000,38 +1020,62 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
             }
         )->shouldBeCalled();
 
+        $second_call = function ($args) use ($that) {
+            $references = $args[0];
+            $that->assertEquals(3, count($references));
+
+            $that->assertArrayHasKey('foo/bar', $references);
+            $that->assertArrayHasKey('monolog/monolog', $references);
+            $that->assertArrayHasKey('foo/baz', $references);
+
+            $that->assertSame($references['foo/bar'], '1234567');
+            $that->assertSame($references['monolog/monolog'], 'cb641a8');
+            $that->assertSame($references['foo/baz'], 'abc1234');
+        };
+
+        $root->setReferences(Argument::type('array'))->will($second_call);
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+
+        // Test with onInit event.
         $root->setReferences(Argument::type('array'))->will(
-            function ($args) use ($that) {
+            function ($args) use ($that, $root, $second_call) {
                 $references = $args[0];
-                $that->assertEquals(3, count($references));
+                $that->assertEquals(2, count($references));
 
                 $that->assertArrayHasKey('foo/bar', $references);
                 $that->assertArrayHasKey('monolog/monolog', $references);
-                $that->assertArrayHasKey('foo/baz', $references);
 
                 $that->assertSame($references['foo/bar'], '1234567');
                 $that->assertSame($references['monolog/monolog'], 'cb641a8');
-                $that->assertSame($references['foo/baz'], 'abc1234');
+
+                // onInit does parse without require-dev, so this is called a
+                // second time when onInstallUpdateOrDump() fires with the dev
+                // section parsed as well.
+                $root->setReferences(Argument::type('array'))->will($second_call);
             }
         );
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir, true);
     }
 
 
     /**
      * @param RootPackage $package
      * @param string $directory Working directory for composer run
+     * @param bool $use_init_event If the init event should be triggered.
      * @return array Constrains added by MergePlugin::onDependencySolve
      */
-    protected function triggerPlugin($package, $directory)
+    protected function triggerPlugin($package, $directory, $use_init_event = false)
     {
         chdir($directory);
         $this->composer->getPackage()->willReturn($package);
 
         $event = new \Composer\EventDispatcher\Event(
-            MergePlugin::INIT
+            MergePlugin::COMPAT_PLUGINEVENTS_INIT
         );
-        $this->fixture->onInit($event);
+        if ($use_init_event) {
+            $this->fixture->onInit($event);
+        }
 
         $event = new Event(
             ScriptEvents::PRE_INSTALL_CMD,

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -25,6 +25,7 @@ use Composer\Package\Locker;
 use Composer\Package\Package;
 use Composer\Package\RootPackage;
 use Composer\Package\Version\VersionParser;
+use Composer\Plugin\PluginEvents;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 use Prophecy\Argument;
@@ -71,11 +72,12 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
     public function testSubscribedEvents()
     {
         $subscriptions = MergePlugin::getSubscribedEvents();
-        $this->assertEquals(7, count($subscriptions));
+        $this->assertEquals(8, count($subscriptions));
         $this->assertArrayHasKey(
             InstallerEvents::PRE_DEPENDENCIES_SOLVING,
             $subscriptions
         );
+        $this->assertArrayHasKey(PluginEvents::INIT, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_INSTALL_CMD, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_UPDATE_CMD, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_AUTOLOAD_DUMP, $subscriptions);
@@ -1025,6 +1027,11 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
     {
         chdir($directory);
         $this->composer->getPackage()->willReturn($package);
+
+        $event = new \Composer\EventDispatcher\Event(
+            PluginEvents::INIT
+        );
+        $this->fixture->onInit($event);
 
         $event = new Event(
             ScriptEvents::PRE_INSTALL_CMD,


### PR DESCRIPTION
Composer just added a very handy INIT event for 1.1 (and 1.1 is out now) 

(https://github.com/composer/composer/issues/5232#issuecomment-213563205).

### Notes

- It is possible to just use 'init' (or a constant within the same class) instead of updating to PluginEvents 1.1.0 API.
- devMode is a little problematic as one can see as it probably cannot be determined at init() time.

This makes custom installers work correctly with the merge plugin - without having to use hacks (https://github.com/douggreen/drupal-composer-installer/pull/9).

PS: Overall this could simplify the merge plugin a lot - as now in theory just merging files once after plugin initialization could be enough - except for when it is installed in the same moment.