### PR TITLE
Use dev mode flag from event in onDependencySolve callback

### DIFF
--- a/src/Merge/PluginState.php
+++ b/src/Merge/PluginState.php
@@ -246,7 +246,17 @@ class PluginState
      */
     public function isDevMode()
     {
-        return $this->mergeDev && $this->devMode;
+        return $this->shouldMergeDev() && $this->devMode;
+    }
+
+    /**
+     * Should devMode settings be merged?
+     *
+     * @return bool
+     */
+    public function shouldMergeDev()
+    {
+        return $this->mergeDev;
     }
 
     /**

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -279,7 +279,12 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             );
             $request->install($link->getTarget(), $link->getConstraint());
         }
-        if ($this->state->isDevMode()) {
+
+        // Issue #113: Check devMode of event rather than our global state.
+        // Composer fires the PRE_DEPENDENCIES_SOLVING event twice for
+        // `--no-dev` operations to decide which packages are dev only
+        // requirements.
+        if ($this->state->shouldMergeDev() && $event->isDevMode()) {
             foreach ($this->state->getDuplicateLinks('require-dev') as $link) {
                 $this->logger->info(
                     "Adding dev dependency <comment>{$link}</comment>"


### PR DESCRIPTION
Composer determines if a given package is a dev mode dependency by
running a solver with dev mode disabled and diffing the result against
the full solver run. This causes every run to two emit
`InstallerEvents::PRE_DEPENDENCIES_SOLVING` events: one with dev mode
enabled and one without. Previously we were using the global dev mode
state set by the main install/update/dump event for both calls. This led
Composer to believe that all conflicting pacakges processed by
composer-merge-plugin were non-dev requirements and an unexpected
composer.lock state for later `composer install --no-dev` executions.

Closes #113