### PR TITLE
Always prepend repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ extensions which may be managed via Composer.
 Installation
 ------------
 
+Composer Merge Plugin requires Composer 1.0.0 or newer.
+
 ```
 $ composer require wikimedia/composer-merge-plugin
 ```

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.2"
     },
     "require-dev": {
-        "composer/composer": "1.0.*@dev",
+        "composer/composer": "~1.0.0",
         "jakub-onderka/php-parallel-lint": "~0.8",
         "phpunit/phpunit": "~4.8|~5.0",
         "squizlabs/php_codesniffer": "~2.1.0"

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -152,7 +152,7 @@ class ExtraPackage
      */
     public function mergeInto(RootPackageInterface $root, PluginState $state)
     {
-        $this->addRepositories($root, $state->shouldPrependRepositories());
+        $this->prependRepositories($root);
 
         $this->mergeRequires('require', $root, $state);
 
@@ -191,9 +191,8 @@ class ExtraPackage
      * to the given package and the global repository manager.
      *
      * @param RootPackageInterface $root
-     * @param bool $prepend Should repositories be prepended to repository manager.
      */
-    protected function addRepositories(RootPackageInterface $root, $prepend)
+    protected function prependRepositories(RootPackageInterface $root)
     {
         if (!isset($this->json['repositories'])) {
             return;
@@ -205,35 +204,20 @@ class ExtraPackage
             if (!isset($repoJson['type'])) {
                 continue;
             }
-            if ($prepend) {
-                $this->logger->info("Prepending {$repoJson['type']} repository");
-            } else {
-                $this->logger->info("Adding {$repoJson['type']} repository");
-            }
+            $this->logger->info("Prepending {$repoJson['type']} repository");
             $repo = $repoManager->createRepository(
                 $repoJson['type'],
                 $repoJson
             );
-            if ($prepend) {
-                $repoManager->prependRepository($repo);
-            } else {
-                $repoManager->addRepository($repo);
-            }
+            $repoManager->prependRepository($repo);
             $newRepos[] = $repo;
         }
 
         $unwrapped = self::unwrapIfNeeded($root, 'setRepositories');
-        if ($prepend) {
-            $unwrapped->setRepositories(array_merge(
-                $newRepos,
-                $root->getRepositories()
-            ));
-        } else {
-            $unwrapped->setRepositories(array_merge(
-                $root->getRepositories(),
-                $newRepos
-            ));
-        }
+        $unwrapped->setRepositories(array_merge(
+            $newRepos,
+            $root->getRepositories()
+        ));
     }
 
     /**

--- a/src/Merge/PluginState.php
+++ b/src/Merge/PluginState.php
@@ -75,13 +75,6 @@ class PluginState
     protected $mergeExtra = false;
 
     /**
-     * Whether to prepend repositories to repository manager.
-     *
-     * @var bool $prependRepositories
-     */
-    protected $prependRepositories = false;
-
-    /**
      * Whether to merge the extra section in a deep / recursive way.
      *
      * By default the extra section is merged with array_merge() and duplicate
@@ -139,7 +132,6 @@ class PluginState
                 'require' => array(),
                 'recurse' => true,
                 'replace' => false,
-                'prepend-repositories' => false,
                 'merge-dev' => true,
                 'merge-extra' => false,
                 'merge-extra-deep' => false,
@@ -153,7 +145,6 @@ class PluginState
             $config['require'] : array($config['require']);
         $this->recurse = (bool)$config['recurse'];
         $this->replace = (bool)$config['replace'];
-        $this->prependRepositories = (bool)$config['prepend-repositories'];
         $this->mergeDev = (bool)$config['merge-dev'];
         $this->mergeExtra = (bool)$config['merge-extra'];
         $this->mergeExtraDeep = (bool)$config['merge-extra-deep'];
@@ -351,16 +342,6 @@ class PluginState
     public function shouldMergeExtra()
     {
         return $this->mergeExtra;
-    }
-
-    /**
-     * Should the merger prepend repositories to repository manager (instead of adding them to end of the list).
-     *
-     * @return bool
-     */
-    public function shouldPrependRepositories()
-    {
-        return $this->prependRepositories;
     }
 
     /**

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -348,7 +348,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
                 );
             }
         );
-        $repoManager->addRepository(Argument::any())->will(
+        $repoManager->prependRepository(Argument::any())->will(
             function ($args) use ($that) {
                 $that->assertInstanceOf(
                     'Composer\Repository\VcsRepository',
@@ -396,7 +396,6 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Given a root package with an extra section
-     *   and prepend-repositories mode is active
      *   and a composer.local.json with a repository
      * When the plugin is run
      * Then the repository from composer.local.json should be prepended to root package repository list
@@ -857,7 +856,7 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
                 new \Composer\Config()
             );
         });
-        $repoManager->addRepository(Argument::any())->shouldBeCalled();
+        $repoManager->prependRepository(Argument::any())->shouldBeCalled();
         $this->composer->getRepositoryManager()->will(
             function () use ($repoManager) {
                 return $repoManager->reveal();

--- a/tests/phpunit/fixtures/testPrependRepositories/composer.json
+++ b/tests/phpunit/fixtures/testPrependRepositories/composer.json
@@ -10,8 +10,7 @@
     },
     "extra": {
         "merge-plugin": {
-            "include": "composer.local.json",
-            "prepend-repositories": true
+            "include": "composer.local.json"
         }
     }
 }


### PR DESCRIPTION
Follow up to 9645a93 that makes the use of
RepositoryManager::prependRepository() the default behavior for all
repository merges. This ensures that epos added by the included/required
config files to have a higher priority than the repos added in the root
composer.json and most importantly higher than the default packagist
repo.

Closes #95