### PR TITLE
fixed relative paths for "required", "include" and "path repository" …

### DIFF
--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -86,7 +86,7 @@ class ExtraPackage
     public function getIncludes()
     {
         return isset($this->json['extra']['merge-plugin']['include']) ?
-            $this->json['extra']['merge-plugin']['include'] : array();
+            $this->fixRelativePaths($this->json['extra']['merge-plugin']['include']) : array();
     }
 
     /**
@@ -97,7 +97,7 @@ class ExtraPackage
     public function getRequires()
     {
         return isset($this->json['extra']['merge-plugin']['require']) ?
-            $this->json['extra']['merge-plugin']['require'] : array();
+            $this->fixRelativePaths($this->json['extra']['merge-plugin']['require']) : array();
     }
 
     /**
@@ -205,6 +205,9 @@ class ExtraPackage
         foreach ($this->json['repositories'] as $repoJson) {
             if (!isset($repoJson['type'])) {
                 continue;
+            }
+            if ($repoJson['type'] == 'path' && isset($repoJson['url'])) {
+                $repoJson['url'] = $this->fixRelativePaths(array($repoJson['url']))[0];
             }
             $this->logger->info("Prepending {$repoJson['type']} repository");
             $repo = $repoManager->createRepository(

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -300,6 +300,40 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($extraInstalls));
     }
 
+    /**
+     * Given a root package with no requires
+     *   and a subdirectory/composer.local.json with one require, which includes a composer.local.2.json
+     *   and a subdirectory/composer.local.2.json with one additional require
+     * When the plugin is run
+     * Then the root package should inherit both requires
+     *   and no modifications should be made by the pre-dependency hook.
+     */
+    public function testRecursiveIncludesWithSubDirectory()
+    {
+        $dir = $this->fixtureDir(__FUNCTION__);
+
+        $root = $this->rootFromJson("{$dir}/composer.json");
+
+        $packages = array();
+        $root->setRequires(Argument::type('array'))->will(
+            function ($args) use (&$packages) {
+                $packages = array_merge($packages, $args[0]);
+            }
+        );
+
+        $root->getRepositories()->shouldNotBeCalled();
+        $root->getConflicts()->shouldNotBeCalled();
+        $root->getReplaces()->shouldNotBeCalled();
+        $root->getProvides()->shouldNotBeCalled();
+        $root->getSuggests()->shouldNotBeCalled();
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+
+        $this->assertArrayHasKey('foo', $packages);
+        $this->assertArrayHasKey('monolog/monolog', $packages);
+
+        $this->assertEquals(0, count($extraInstalls));
+    }
 
     /**
      * Given a root package with no requires that disables recursion
@@ -336,6 +370,161 @@ class MergePluginTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($extraInstalls));
     }
 
+    /**
+     * Given a root package with no requires
+     *   and a subdirectory/composer.local.json with one require, which includes a composer.local.2.json
+     *   and a subdirectory/composer.local.2.json with one additional require and a repository of type 'path'
+     *   and url with a value of 'localdirectory'
+     * When the plugin is run
+     * Then the root package should inherit both requires
+     *   and should have the repository path url fixed to 'subdirectory/localdirectory'
+     *   and no modifications should be made by the pre-dependency hook.
+     */
+    public function testRecursivePathRepositoriesWithSubDirectory()
+    {
+        $that = $this;
+        $io = $this->io;
+        $dir = $this->fixtureDir(__FUNCTION__);
+
+        $repoManager = $this->prophesize(
+            'Composer\Repository\RepositoryManager'
+        );
+        $repoManager->createRepository(
+            Argument::type('string'),
+            Argument::type('array')
+        )->will(
+            function ($args) use ($that, $io) {
+                $that->assertEquals('path', $args[0]);
+                $that->assertEquals(
+                    'subdirectory/local/directory',
+                    $args[1]['url']
+                );
+
+                return new \Composer\Repository\PathRepository(
+                    $args[1],
+                    $io->reveal(),
+                    new \Composer\Config()
+                );
+            }
+        );
+        $repoManager->prependRepository(Argument::any())->will(
+            function ($args) use ($that) {
+                $that->assertInstanceOf(
+                    'Composer\Repository\PathRepository',
+                    $args[0]
+                );
+            }
+        );
+        $this->composer->getRepositoryManager()->will(
+            function () use ($repoManager) {
+                return $repoManager->reveal();
+            }
+        );
+
+        $root = $this->rootFromJson("{$dir}/composer.json");
+
+        $packages = array();
+        $root->setRequires(Argument::type('array'))->will(
+            function ($args) use (&$packages) {
+                $packages = array_merge($packages, $args[0]);
+            }
+        );
+
+        $root->setDevRequires()->shouldNotBeCalled();
+
+        $root->setRepositories(Argument::type('array'))->will(
+            function ($args) use ($that) {
+                $repos = $args[0];
+                $that->assertEquals(1, count($repos));
+            }
+        );
+
+        $root->getConflicts()->shouldNotBeCalled();
+        $root->getReplaces()->shouldNotBeCalled();
+        $root->getProvides()->shouldNotBeCalled();
+        $root->getSuggests()->shouldNotBeCalled();
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+
+        $this->assertArrayHasKey('foo', $packages);
+        $this->assertArrayHasKey('wikimedia/composer-merge-plugin', $packages);
+
+        $this->assertEquals(0, count($extraInstalls));
+    }
+
+
+    /**
+     * Given a root package with no requires
+     *   and a composer.local.json with one require, which requires a composer.local.2.json
+     *   and a composer.local.2.json with one additional require
+     * When the plugin is run
+     * Then the root package should inherit both requires
+     *   and no modifications should be made by the pre-dependency hook.
+     */
+    public function testRecursiveRequires()
+    {
+        $dir = $this->fixtureDir(__FUNCTION__);
+
+        $root = $this->rootFromJson("{$dir}/composer.json");
+
+        $packages = array();
+
+        $root->setRequires(Argument::type('array'))->will(
+            function ($args) use (&$packages) {
+                $packages = array_merge($packages, $args[0]);
+            }
+        );
+
+        $root->getRepositories()->shouldNotBeCalled();
+        $root->getConflicts()->shouldNotBeCalled();
+        $root->getReplaces()->shouldNotBeCalled();
+        $root->getProvides()->shouldNotBeCalled();
+        $root->getSuggests()->shouldNotBeCalled();
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+
+
+
+        $this->assertArrayHasKey('foo', $packages);
+        $this->assertArrayHasKey('monolog/monolog', $packages);
+
+        $this->assertEquals(0, count($extraInstalls));
+    }
+
+    /**
+     * Given a root package with no requires
+     *   and a subdirectory/composer.local.json with one require, which requires a composer.local.2.json
+     *   and a subdirectory/composer.local.2.json with one additional require
+     * When the plugin is run
+     * Then the root package should inherit both requires
+     *   and no modifications should be made by the pre-dependency hook.
+     */
+    public function testRecursiveRequiresWithSubDirectory()
+    {
+        $dir = $this->fixtureDir(__FUNCTION__);
+
+        $root = $this->rootFromJson("{$dir}/composer.json");
+
+        $packages = array();
+        $root->setRequires(Argument::type('array'))->will(
+            function ($args) use (&$packages) {
+                $packages = array_merge($packages, $args[0]);
+            }
+        );
+
+        $root->getRepositories()->shouldNotBeCalled();
+        $root->getConflicts()->shouldNotBeCalled();
+        $root->getReplaces()->shouldNotBeCalled();
+        $root->getProvides()->shouldNotBeCalled();
+        $root->getSuggests()->shouldNotBeCalled();
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+
+        $this->assertArrayHasKey('foo', $packages);
+        $this->assertArrayHasKey('monolog/monolog', $packages);
+
+        $this->assertEquals(0, count($extraInstalls));
+    }
 
     /**
      * Given a root package with requires

--- a/tests/phpunit/fixtures/testRecursiveIncludesWithSubDirectory/composer.json
+++ b/tests/phpunit/fixtures/testRecursiveIncludesWithSubDirectory/composer.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "subdirectory/composer.local.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveIncludesWithSubDirectory/subdirectory/composer.local.2.json
+++ b/tests/phpunit/fixtures/testRecursiveIncludesWithSubDirectory/subdirectory/composer.local.2.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "monolog/monolog": "~1.0"
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveIncludesWithSubDirectory/subdirectory/composer.local.json
+++ b/tests/phpunit/fixtures/testRecursiveIncludesWithSubDirectory/subdirectory/composer.local.json
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "foo": "1.0.0"
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "composer.local.2.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursivePathRepositoriesWithSubDirectory/composer.json
+++ b/tests/phpunit/fixtures/testRecursivePathRepositoriesWithSubDirectory/composer.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "subdirectory/composer.local.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursivePathRepositoriesWithSubDirectory/subdirectory/composer.local.2.json
+++ b/tests/phpunit/fixtures/testRecursivePathRepositoriesWithSubDirectory/subdirectory/composer.local.2.json
@@ -1,0 +1,11 @@
+{
+	"require": {
+		"wikimedia/composer-merge-plugin": "dev-master#deadbeef"
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "local/directory"
+		}
+	]
+}

--- a/tests/phpunit/fixtures/testRecursivePathRepositoriesWithSubDirectory/subdirectory/composer.local.json
+++ b/tests/phpunit/fixtures/testRecursivePathRepositoriesWithSubDirectory/subdirectory/composer.local.json
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "foo": "1.0.0"
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "composer.local.2.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveRequires/composer.json
+++ b/tests/phpunit/fixtures/testRecursiveRequires/composer.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "require": [
+                "composer.local.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveRequires/composer.local.2.json
+++ b/tests/phpunit/fixtures/testRecursiveRequires/composer.local.2.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "monolog/monolog": "~1.0"
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveRequires/composer.local.json
+++ b/tests/phpunit/fixtures/testRecursiveRequires/composer.local.json
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "foo": "1.0.0"
+    },
+    "extra": {
+        "merge-plugin": {
+            "require": [
+                "composer.local.2.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveRequiresWithSubDirectory/composer.json
+++ b/tests/phpunit/fixtures/testRecursiveRequiresWithSubDirectory/composer.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "require": [
+                "subdirectory/composer.local.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveRequiresWithSubDirectory/subdirectory/composer.local.2.json
+++ b/tests/phpunit/fixtures/testRecursiveRequiresWithSubDirectory/subdirectory/composer.local.2.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "monolog/monolog": "~1.0"
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveRequiresWithSubDirectory/subdirectory/composer.local.json
+++ b/tests/phpunit/fixtures/testRecursiveRequiresWithSubDirectory/subdirectory/composer.local.json
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "foo": "1.0.0"
+    },
+    "extra": {
+        "merge-plugin": {
+            "require": [
+                "composer.local.2.json"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
…during recursion see #161 

Added test cases for each.