### PR TITLE
Create-replace option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Usage
             "merge-dev": true,
             "merge-extra": false,
             "merge-extra-deep": false,
-            "merge-scripts": false
+            "merge-scripts": false,
+            "create-replace": false
         }
     }
 }
@@ -172,6 +173,11 @@ Note: [custom commands][] added by merged configuration will work when invoked
 as `composer run-script my-cool-command` but will not be available using the
 normal `composer my-cool-command` shortcut.
 
+### create-replace
+
+A `"create-replace": true` setting enables that all found sub packages are added
+inside the `"replace"` section of the root package. This option helps you if you
+have sub packages which requires each other.
 
 Running tests
 -------------

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -78,6 +78,11 @@ class ExtraPackage
         $this->versionParser = new VersionParser();
     }
 
+    public function getName()
+    {
+        return $this->json['name'];
+    }
+
     /**
      * Get list of additional packages to include if precessing recursively.
      *
@@ -233,7 +238,8 @@ class ExtraPackage
         $type,
         RootPackageInterface $root,
         PluginState $state
-    ) {
+    )
+    {
         $linkType = BasePackage::$supportedLinkTypes[$type];
         $getter = 'get' . ucfirst($linkType['method']);
         $setter = 'set' . ucfirst($linkType['method']);
@@ -274,7 +280,8 @@ class ExtraPackage
         array $origin,
         array $merge,
         $state
-    ) {
+    )
+    {
         if ($state->ignoreDuplicateLinks() && $state->replaceDuplicateLinks()) {
             $this->logger->warning("Both replace and ignore-duplicates are true. These are mutually exclusive.");
             $this->logger->warning("Duplicate packages will be ignored.");
@@ -354,7 +361,8 @@ class ExtraPackage
     protected function mergeStabilityFlags(
         RootPackageInterface $root,
         array $requires
-    ) {
+    )
+    {
         $flags = $root->getStabilityFlags();
         $sf = new StabilityFlags($flags, $root->getMinimumStability());
 
@@ -436,11 +444,11 @@ class ExtraPackage
         } else {
             if (!$state->shouldMergeExtraDeep()) {
                 foreach (array_intersect(
-                    array_keys($extra),
-                    array_keys($rootExtra)
-                ) as $key) {
+                             array_keys($extra),
+                             array_keys($rootExtra)
+                         ) as $key) {
                     $this->logger->info(
-                        "Ignoring duplicate <comment>{$key}</comment> in ".
+                        "Ignoring duplicate <comment>{$key}</comment> in " .
                         "<comment>{$this->path}</comment> extra config."
                     );
                 }
@@ -508,7 +516,8 @@ class ExtraPackage
         $type,
         array $links,
         RootPackageInterface $root
-    ) {
+    )
+    {
         $linkType = BasePackage::$supportedLinkTypes[$type];
         $version = $root->getVersion();
         $prettyVersion = $root->getPrettyVersion();
@@ -566,7 +575,8 @@ class ExtraPackage
     public static function unwrapIfNeeded(
         RootPackageInterface $root,
         $method = 'setExtra'
-    ) {
+    )
+    {
         // @codeCoverageIgnoreStart
         if ($root instanceof RootAliasPackage &&
             !method_exists($root, $method)
@@ -591,7 +601,7 @@ class ExtraPackage
         $unwrapped = $this->unwrapIfNeeded($root, 'setReferences');
         foreach (array('require', 'require-dev') as $linkType) {
             $linkInfo = BasePackage::$supportedLinkTypes[$linkType];
-            $method = 'get'.ucfirst($linkInfo['method']);
+            $method = 'get' . ucfirst($linkInfo['method']);
             $links = array();
             foreach ($unwrapped->$method() as $link) {
                 $links[$link->getTarget()] = $link->getConstraint()->getPrettyString();

--- a/src/Merge/PluginState.php
+++ b/src/Merge/PluginState.php
@@ -125,6 +125,11 @@ class PluginState
     protected $optimizeAutoloader = false;
 
     /**
+     * @var bool $createReplace
+     */
+    protected $createReplace = false;
+
+    /**
      * @param Composer $composer
      */
     public function __construct(Composer $composer)
@@ -149,6 +154,7 @@ class PluginState
                 'merge-extra' => false,
                 'merge-extra-deep' => false,
                 'merge-scripts' => false,
+                'create-replace' => false
             ),
             isset($extra['merge-plugin']) ? $extra['merge-plugin'] : array()
         );
@@ -164,6 +170,7 @@ class PluginState
         $this->mergeExtra = (bool)$config['merge-extra'];
         $this->mergeExtraDeep = (bool)$config['merge-extra-deep'];
         $this->mergeScripts = (bool)$config['merge-scripts'];
+        $this->createReplace = (bool)$config['create-replace'];
     }
 
     /**
@@ -413,5 +420,16 @@ class PluginState
     {
         return $this->mergeScripts;
     }
+
+    /**
+     * Should the root package add all sub-packages to the root "replace"
+     *
+     * @return bool
+     */
+    public function shouldCreateReplace()
+    {
+        return $this->createReplace;
+    }
+
 }
 // vim:sw=4:ts=4:sts=4:et:

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -263,6 +263,20 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             $package->mergeInto($root, $this->state);
         }
 
+        //should replaced
+        if ($this->state->shouldCreateReplace()) {
+            $replaces = $root->getReplaces();
+            $replaces[$package->getName()] = new \Composer\Package\Link(
+                $root->getName(),
+                $package->getName(),
+                new \Composer\Semver\Constraint\Constraint('=', $root->getVersion()),
+                'replaces',
+                'self.version'
+            );
+            $root->setReplaces($replaces);
+            $this->logger->info("Added <comment>{$package->getName()}</comment> to replace section of {$root->getName()}");
+        }
+
         if ($this->state->isDevMode()) {
             $this->loaded[$path] = true;
         } else {


### PR DESCRIPTION
This PR adds the "create-replace" option to the merge plugin.

The option is required when you have sub packages which depends on each other, e.g. you have a sub package "a" and this package requires sub package "b", composer suggests the "replace" option on the root level.

The new option adds all sub packages to the root level "replace" and solves this problem for you.