### PR TITLE
Add support for passing original command-line options to installer

### DIFF
--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -388,6 +388,8 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
 
             $preferSource = $input->getOption('prefer-source') || $config->get('preferred-install') == 'source';
             $preferDist = $input->getOption('prefer-dist') || $config->get('preferred-install') == 'dist';
+            $preferStable = $input->hasOption('prefer-stable') ? $input->getOption('prefer-stable') : $config->get('prefer-stable');
+            $preferLowest = $input->hasOption('prefer-lowest') ? $input->getOption('prefer-lowest') : false;
             $optimize = $input->getOption('optimize-autoloader') || $this->state->shouldOptimizeAutoloader();
             $authoritative = $input->getOption('classmap-authoritative')
                || $this->composer->getConfig()->get('classmap-authoritative');
@@ -404,8 +406,8 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
               ->setClassMapAuthoritative($authoritative)
               ->setApcuAutoloader($apcu)
               ->setIgnorePlatformRequirements($input->getOption('ignore-platform-reqs'))
-              ->setPreferStable($input->getOption('prefer-stable'))
-              ->setPreferLowest($input->getOption('prefer-lowest'))
+              ->setPreferStable($preferStable)
+              ->setPreferLowest($preferLowest)
               ->setDryRun($input->getOption('dry-run'));
 
             if (in_array($argv[1], array('install', 'update'))) {

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -403,17 +403,21 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
               ->setDumpAutoloader($this->state->shouldDumpAutoloader())
               ->setClassMapAuthoritative($authoritative)
               ->setApcuAutoloader($apcu)
-              ->setWhitelistTransitiveDependencies($input->getOption('update-with-dependencies'))
-              ->setWhitelistAllDependencies($input->getOption('update-with-all-dependencies'))
               ->setIgnorePlatformRequirements($input->getOption('ignore-platform-reqs'))
               ->setPreferStable($input->getOption('prefer-stable'))
               ->setPreferLowest($input->getOption('prefer-lowest'))
               ->setDryRun($input->getOption('dry-run'));
 
-            if (in_array($argv[1], array('install', 'require'))) {
+            if (in_array($argv[1], array('install', 'update'))) {
                 $installer->setDevMode(!$input->getOption('no-dev') || $event->isDevMode());
+                if ($argv[1] === 'update') {
+                    $installer->setWhitelistAllDependencies($input->getOption('with-all-dependencies'));
+                    $installer->setWhitelistTransitiveDependencies($input->getOption('with-dependencies'));
+                }
             } elseif ($argv[1] === 'require') {
                 $installer->setDevMode(!$input->getOption('update-no-dev') || $event->isDevMode());
+                $installer->setWhitelistAllDependencies($input->getOption('update-with-all-dependencies'));
+                $installer->setWhitelistTransitiveDependencies($input->getOption('update-with-dependencies'));
             }
 
             if ($this->state->forceUpdate()) {

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -344,10 +344,28 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
 
             $config = $this->composer->getConfig();
 
-            // \Composer\XdebugHandler::getScriptArgs() adds an "--ansi"
-            // argument which is not recognized by Composer commands.
-            $argv = array_filter($_SERVER['argv'], function($arg) {
-                return $arg !== '--ansi';
+            // See: https://getcomposer.org/doc/03-cli.md#global-options
+            // This could have be collected from
+            // Composer\Console\Application::getDefinition() but it would have
+            // been more resource intensive.
+            // Hint: --verbose (-v) is intentionally not blacklisted.
+            $global_options_blacklist = array(
+                '--help',
+                '--quiet',
+                '--no-interaction',
+                '-n',
+                '--no-plugins',
+                '--working-dir',
+                '-d',
+                '--profile',
+                '--ansi',
+                '--no-ansi',
+                '--version',
+                '-V',
+            );
+            // Filter out all global options that are not supported by commands.
+            $argv = array_filter($_SERVER['argv'], function($arg) use ($global_options_blacklist) {
+                return !in_array($arg, $global_options_blacklist);
             });
             if ($argv[1] === 'update') {
                 $command = new UpdateCommand();


### PR DESCRIPTION
Merge plugin did not respected `--prefer-lowest` option so highest-lowest testing could not be achieved with it. This PR fixes this problem and also fixes some others:

- https://github.com/wikimedia/composer-merge-plugin/issues/167
- https://github.com/wikimedia/composer-merge-plugin/issues/159