### PR TITLE
Allow merging "scripts" in a deep way

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Usage
             "merge-dev": true,
             "merge-extra": false,
             "merge-extra-deep": false,
-            "merge-scripts": false
+            "merge-scripts": false,
+            "merge-scripts-deep": false
         }
     }
 }
@@ -177,7 +178,10 @@ scripts section is to accept the first version of any key found (e.g. a key in
 the master config wins over the version found in any imported config). If
 `replace` mode is active ([see above](#replace)) then this behavior changes
 and the last key found will win (e.g. the key in the master config is replaced
-by the key in the imported config).
+by the key in the imported config). If `"merge-scripts-deep": true` is
+specified then, the sections are merged similar to array_merge_recursive() -
+however duplicate string array keys are replaced instead of merged, while
+numeric array keys are merged as usual.
 
 Note: [custom commands][] added by merged configuration will work when invoked
 as `composer run-script my-cool-command` but will not be available using the

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -469,11 +469,11 @@ class ExtraPackage
 
         if ($state->replaceDuplicateLinks()) {
             $unwrapped->setScripts(
-                array_merge($rootScripts, $scripts)
+                self::mergeExtraArray($state->shouldMergeScriptsDeep(), $rootScripts, $scripts)
             );
         } else {
             $unwrapped->setScripts(
-                array_merge($scripts, $rootScripts)
+                self::mergeExtraArray($state->shouldMergeScriptsDeep(), $scripts, $rootScripts)
             );
         }
     }

--- a/src/Merge/PluginState.php
+++ b/src/Merge/PluginState.php
@@ -105,6 +105,20 @@ class PluginState
     protected $mergeScripts = false;
 
     /**
+     * Whether to merge the scripts section in a deep / recursive way.
+     *
+     * By default the scripts section is merged with array_merge() and duplicate
+     * keys are ignored. When enabled this allows to merge the arrays recursively
+     * using the following rule: Integer keys are merged, while array values are
+     * replaced where the later values overwrite the former.
+     *
+     * When 'replace' mode is activated the order of array merges is exchanged.
+     *
+     * @var bool $mergeScriptsDeep
+     */
+    protected $mergeScriptsDeep;
+
+    /**
      * @var bool $firstInstall
      */
     protected $firstInstall = false;
@@ -149,6 +163,7 @@ class PluginState
                 'merge-extra' => false,
                 'merge-extra-deep' => false,
                 'merge-scripts' => false,
+                'merge-scripts-deep' => false,
             ),
             isset($extra['merge-plugin']) ? $extra['merge-plugin'] : array()
         );
@@ -164,6 +179,7 @@ class PluginState
         $this->mergeExtra = (bool)$config['merge-extra'];
         $this->mergeExtraDeep = (bool)$config['merge-extra-deep'];
         $this->mergeScripts = (bool)$config['merge-scripts'];
+        $this->mergeScriptsDeep = (bool)$config['merge-scripts-deep'];
     }
 
     /**
@@ -412,6 +428,23 @@ class PluginState
     public function shouldMergeScripts()
     {
         return $this->mergeScripts;
+    }
+
+    /**
+     * Should the scripts section be merged deep / recursively?
+     *
+     * By default the scripts section is merged with array_merge() and duplicate
+     * keys are ignored. When enabled this allows to merge the arrays recursively
+     * using the following rule: Integer keys are merged, while array values are
+     * replaced where the later values overwrite the former.
+     *
+     * When 'replace' mode is activated the order of array merges is exchanged.
+     *
+     * @return bool
+     */
+    public function shouldMergeScriptsDeep()
+    {
+        return $this->mergeScriptsDeep;
     }
 }
 // vim:sw=4:ts=4:sts=4:et:

--- a/tests/phpunit/fixtures/testMergeScriptsDeep/composer.json
+++ b/tests/phpunit/fixtures/testMergeScriptsDeep/composer.json
@@ -1,0 +1,14 @@
+{
+    "scripts": {
+        "example-script": [
+            "echo 'hello world'"
+        ]
+    },
+    "extra": {
+        "merge-plugin": {
+            "merge-scripts": true,
+            "merge-scripts-deep": true,
+            "include": "composer.local.json"
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testMergeScriptsDeep/composer.local.json
+++ b/tests/phpunit/fixtures/testMergeScriptsDeep/composer.local.json
@@ -1,0 +1,8 @@
+{
+    "scripts": {
+        "example-script": [
+            "echo 'hello again world'"
+        ],
+        "example-script2": "echo 'hello world'"
+    }
+}

--- a/tests/phpunit/fixtures/testMergeScriptsDeepReplace/composer.json
+++ b/tests/phpunit/fixtures/testMergeScriptsDeepReplace/composer.json
@@ -1,0 +1,15 @@
+{
+    "scripts": {
+        "example-script": [
+            "echo 'hello world'"
+        ]
+    },
+    "extra": {
+        "merge-plugin": {
+            "merge-scripts": true,
+            "merge-scripts-deep": true,
+            "replace": true,
+            "include": "composer.local.json"
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testMergeScriptsDeepReplace/composer.local.json
+++ b/tests/phpunit/fixtures/testMergeScriptsDeepReplace/composer.local.json
@@ -1,0 +1,8 @@
+{
+    "scripts": {
+        "example-script": [
+            "echo 'hello again world'"
+        ],
+        "example-script2": "echo 'hello world'"
+    }
+}


### PR DESCRIPTION
Just like `merge-extra-deep`.

Introduce a new `merge-scripts-deep` configuration setting to control
merging the `scripts` section of included/required files in a way similar
to to `array_merge_recursive()` - however duplicate string array keys are
replaced instead of merged, while numeric array keys are merged as
usual.