### PR TITLE
Implement ignore-require

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Usage
             "recurse": true,
             "replace": false,
             "ignore-duplicates": false,
+            "ignore-require": [
+                "vendor/package",
+                "other-vendor/*"
+            ],
             "merge-dev": true,
             "merge-extra": false,
             "merge-extra-deep": false,
@@ -144,6 +148,14 @@ alphabetical order.
 
 Note: `"replace": true` and `"ignore-duplicates": true` modes are mutually
 exclusive. If both are set, `"ignore-duplicates": true` will be used.
+
+### ignore-require
+
+In some cases you might want to ignore requirements imposed by included
+configuration files (e.g. those requirements are fulfilled by other included
+configuration files). This option allows you to set a list of composer-style 
+package name specifications that will get ignored when assembling the
+combined final require statements. 
 
 ### merge-dev
 

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -243,6 +243,18 @@ class ExtraPackage
             return;
         }
 
+        $ignoreRequire = $state->getIgnoreRequire();
+        if (!empty($ignoreRequire)) {
+            $requires = array_filter($requires, function ($name) use ($ignoreRequire) {
+                foreach ($ignoreRequire as $ignorePattern) {
+                    if (fnmatch($ignorePattern, $name)) {
+                        return false;
+                    }
+                }
+                return true;
+            }, ARRAY_FILTER_USE_KEY);
+        }
+
         $this->mergeStabilityFlags($root, $requires);
 
         $requires = $this->replaceSelfVersionDependencies(

--- a/src/Merge/PluginState.php
+++ b/src/Merge/PluginState.php
@@ -60,6 +60,11 @@ class PluginState
     protected $ignore = false;
 
     /**
+     * @var array $ignoreRequire
+     */
+    protected $ignoreRequire = array();
+
+    /**
      * Whether to merge the -dev sections.
      * @var bool $mergeDev
      */
@@ -145,6 +150,7 @@ class PluginState
                 'recurse' => true,
                 'replace' => false,
                 'ignore-duplicates' => false,
+                'ignore-require' => array(),
                 'merge-dev' => true,
                 'merge-extra' => false,
                 'merge-extra-deep' => false,
@@ -160,6 +166,8 @@ class PluginState
         $this->recurse = (bool)$config['recurse'];
         $this->replace = (bool)$config['replace'];
         $this->ignore = (bool)$config['ignore-duplicates'];
+        $this->ignoreRequire = (is_array($config['ignore-require'])) ?
+            $config['ignore-require'] : array($config['ignore-require']);
         $this->mergeDev = (bool)$config['merge-dev'];
         $this->mergeExtra = (bool)$config['merge-extra'];
         $this->mergeExtraDeep = (bool)$config['merge-extra-deep'];
@@ -361,6 +369,16 @@ class PluginState
     public function ignoreDuplicateLinks()
     {
         return $this->ignore;
+    }
+
+    /**
+     * Return an array of require package name specifications that should be ignored
+     *
+     * @return array
+     */
+    public function getIgnoreRequire()
+    {
+        return $this->ignoreRequire;
     }
 
     /**


### PR DESCRIPTION
I was running into the issue that I wanted to include configuration files for packages in the source tree that require each-other. Of course composer shouldn't install these packages into /vendor, so I implemented an option to ignore certain require'd packages.