### PR TITLE
Add support for Composer v2

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,31 +9,45 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions:
+        php-version:
           - "7.2"
           - "7.3"
           - "7.4"
           - "8.0"
+        composer-dependencies:
+          - 'highest'
     env:
       COMPOSER_DISABLE_XDEBUG_WARN: 1
 
-    name: PHP ${{ matrix.php-versions }} test
+    name: Test PHP ${{ matrix.php-version }}
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    
+
     - name: Setup PHP version
       uses: shivammathur/setup-php@v2
       with:
-        php-version: ${{ matrix.php-versions }}
+        php-version: ${{ matrix.php-version }}
         coverage: xdebug
-        tools: composer:v1
+        tools: composer:v2
 
-    - name: Install composer dependencies
-      run: composer install --prefer-dist --no-progress
+    - name: Test Composer v1
+      run: composer require --dev --no-update composer/composer:^1.1
 
-    - name: Run tests
-      run: composer test
+    - uses: "ramsey/composer-install@v1"
+      with:
+        dependency-versions: "${{ matrix.composer-dependencies }}"
+
+    - run: composer test
+
+    - name: Test Composer v2
+      run: composer require --dev --no-update composer/composer:^2.0
+
+    - uses: "ramsey/composer-install@v1"
+      with:
+        dependency-versions: "${{ matrix.composer-dependencies }}"
+
+    - run: composer test
 
   ocular-push:
     runs-on: ubuntu-latest
@@ -57,7 +71,7 @@ jobs:
     - name: Run coverage
       run: composer coverage
 
-    - name: Get ocular
+    - name: Get Ocular
       run: wget https://scrutinizer-ci.com/ocular.phar
 
     - name: Upload code coverage
@@ -68,7 +82,7 @@ jobs:
     if: ${{ always() }} && github.repository == 'wikimedia/composer-merge-plugin'
     needs: [run]
     steps:
-    - name: irc push notification
+    - name: IRC push notification
       uses: rectalogic/notify-irc@v1
       if: github.event_name == 'push'
       with:

--- a/README.md
+++ b/README.md
@@ -24,14 +24,23 @@ extensions which may be managed via Composer.
 Installation
 ------------
 
-Composer Merge Plugin requires [Composer 1.1.0](https://getcomposer.org/) or
-newer, but doesn't currently support Composer 2.0. See
-[PR #189](https://github.com/wikimedia/composer-merge-plugin/pull/189) for
-current progress.
+Composer Merge Plugin 1.4.x (and older) requires Composer 1.x.
+
+Composer Merge Plugin 1.5.x (and newer) is compatible with both Composer 2.x and 1.x.
 
 ```
 $ composer require wikimedia/composer-merge-plugin
 ```
+
+### Upgrading from Composer 1 to 2
+
+If you are already using Composer Merge Plugin 1.4 (or older) and you are updating the plugin to 1.5 (or newer), it is recommended that you update the plugin first using Composer 1.
+
+If you update the incompatible plugin using Composer 2, the plugin will be ignored:
+
+> The "wikimedia/composer-merge-plugin" plugin was skipped because it requires a Plugin API version ("^1.0") that does not match your Composer installation ("2.0.0"). You may need to run composer update with the "--no-plugins" option.
+
+Consequently, Composer will be unaware of the merged dependencies and will remove them requiring you to run `composer update` again to reinstall merged dependencies.
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Usage
 In order for composer-merge-plugin to install dependencies from updated or newly created sub-level `composer.json` files in your project you need to run the command:
 
 ```
-$ composer update --lock
+$ composer update
 ```
 
 This will [instruct Composer to recalculate the file hash](https://getcomposer.org/doc/03-cli.md#update) for the top-level `composer.json` thus triggering composer-merge-plugin to look for the sub-level configuration files and update your dependencies.

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ Usage
 ### Updating sub-levels `composer.json` files
 
 
-In order for composer-merge-plugin to install dependencies from updated or newly created sub-level `composer.json` files in your project you need to run the command:
+In order for Composer Merge Plugin to install dependencies from updated or newly created sub-level `composer.json` files in your project you need to run the command:
 
 ```
 $ composer update
 ```
 
-This will [instruct Composer to recalculate the file hash](https://getcomposer.org/doc/03-cli.md#update) for the top-level `composer.json` thus triggering composer-merge-plugin to look for the sub-level configuration files and update your dependencies.
+This will [instruct Composer to recalculate the file hash](https://getcomposer.org/doc/03-cli.md#update) for the top-level `composer.json` thus triggering Composer Merge Plugin to look for the sub-level configuration files and update your dependencies.
 
 
 Plugin configuration

--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ extensions which may be managed via Composer.
 Installation
 ------------
 
-Composer Merge Plugin 1.4.x (and older) requires Composer 1.x.
+Composer Merge Plugin 1.4.x (and older) requires Composer 1.x.
 
-Composer Merge Plugin 1.5.x (and newer) is compatible with both Composer 2.x and 1.x.
+Composer Merge Plugin 1.5.x (and newer) is compatible with both Composer 2.x and 1.x.
 
 ```
 $ composer require wikimedia/composer-merge-plugin
 ```
 
-### Upgrading from Composer 1 to 2
+### Upgrading from Composer 1 to 2
 
-If you are already using Composer Merge Plugin 1.4 (or older) and you are updating the plugin to 1.5 (or newer), it is recommended that you update the plugin first using Composer 1.
+If you are already using Composer Merge Plugin 1.4 (or older) and you are updating the plugin to 1.5 (or newer), it is recommended that you update the plugin first using Composer 1.
 
-If you update the incompatible plugin using Composer 2, the plugin will be ignored:
+If you update the incompatible plugin using Composer 2, the plugin will be ignored:
 
 > The "wikimedia/composer-merge-plugin" plugin was skipped because it requires a Plugin API version ("^1.0") that does not match your Composer installation ("2.0.0"). You may need to run composer update with the "--no-plugins" option.
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "composer-plugin-api": "^1.1",
+        "composer-plugin-api": "^1.1||^2.0",
         "php": ">=7.2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "composer-plugin-api": "^1.1||^2.0",
-        "php": ">=7.2.0"
+        "php": ">=7.2.0",
+        "composer-plugin-api": "^1.1||^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.1",
+        "composer/composer": "^1.1||^2.0",
         "php-parallel-lint/php-parallel-lint": "~1.1.0",
         "phpunit/phpunit": "^8.5||^9.0",
         "squizlabs/php_codesniffer": "~3.5.4"
@@ -33,7 +33,8 @@
         "class": "Wikimedia\\Composer\\MergePlugin"
     },
     "config": {
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "sort-packages": true
     },
     "scripts": {
         "coverage": [

--- a/example/composer.json
+++ b/example/composer.json
@@ -1,8 +1,11 @@
 {
     "repositories": [
         {
-            "type": "vcs",
-            "url": "./.."
+            "type": "path",
+            "url": "./..",
+            "only": [
+                "wikimedia/composer-merge-plugin"
+            ]
         }
     ],
     "require": {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -87,7 +87,7 @@ class Logger
      *
      * @param string $message
      */
-    protected function log($message)
+    public function log($message)
     {
         if (method_exists($this->inputOutput, 'writeError')) {
             $this->inputOutput->writeError($message);

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -276,7 +276,7 @@ class ExtraPackage
         $type,
         array $origin,
         array $merge,
-        $state
+        PluginState $state
     ) {
         if ($state->ignoreDuplicateLinks() && $state->replaceDuplicateLinks()) {
             $this->logger->warning("Both replace and ignore-duplicates are true. These are mutually exclusive.");
@@ -295,7 +295,7 @@ class ExtraPackage
                     $origin[$name] = $link;
                 } else {
                     $this->logger->info("Merging <comment>{$name}</comment>");
-                    $origin[$name] = $this->mergeConstraints($origin[$name], $link);
+                    $origin[$name] = $this->mergeConstraints($origin[$name], $link, $state);
                 }
             } else {
                 $this->logger->info("Adding <comment>{$name}</comment>");
@@ -303,7 +303,7 @@ class ExtraPackage
             }
         }
 
-        if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '<=')) {
+        if (!$state->isComposer1()) {
             Intervals::clear();
         }
 
@@ -317,16 +317,17 @@ class ExtraPackage
      *
      * @param Link $origin The base package link.
      * @param Link $merge  The related package link to merge.
+     * @param PluginState $state
      * @return Link Merged link.
      */
-    protected function mergeConstraints(Link $origin, Link $merge)
+    protected function mergeConstraints(Link $origin, Link $merge, PluginState $state)
     {
         $parser = $this->versionParser;
 
         $oldPrettyString = $origin->getConstraint()->getPrettyString();
         $newPrettyString = $merge->getConstraint()->getPrettyString();
 
-        if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '>')) {
+        if ($state->isComposer1()) {
             $constraintClass = 'Wikimedia\\Composer\\Merge\\MultiConstraint';
         } else {
             $constraintClass = 'Composer\\Semver\\Constraint\\MultiConstraint';

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -22,6 +22,8 @@ use Composer\Package\RootAliasPackage;
 use Composer\Package\RootPackage;
 use Composer\Package\RootPackageInterface;
 use Composer\Package\Version\VersionParser;
+use Composer\Plugin\PluginInterface;
+use Composer\Semver\Constraint\MultiConstraint as SemverMultiConstraint;
 use UnexpectedValueException;
 
 /**
@@ -280,24 +282,59 @@ class ExtraPackage
             $this->logger->warning("Duplicate packages will be ignored.");
         }
 
-        $dups = array();
         foreach ($merge as $name => $link) {
-            if (isset($origin[$name]) && $state->ignoreDuplicateLinks()) {
-                $this->logger->info("Ignoring duplicate <comment>{$name}</comment>");
-                continue;
-            } elseif (!isset($origin[$name]) || $state->replaceDuplicateLinks()) {
-                $this->logger->info("Merging <comment>{$name}</comment>");
-                $origin[$name] = $link;
+            if (isset($origin[$name])) {
+                if ($state->ignoreDuplicateLinks()) {
+                    $this->logger->info("Ignoring duplicate <comment>{$name}</comment>");
+                    continue;
+                }
+
+                if ($state->replaceDuplicateLinks()) {
+                    $this->logger->info("Replacing <comment>{$name}</comment>");
+                    $origin[$name] = $link;
+                } else {
+                    $this->logger->info("Merging <comment>{$name}</comment>");
+                    $origin[$name] = $this->mergeConstraints($origin[$name], $link);
+                }
             } else {
-                // Defer to solver.
-                $this->logger->info(
-                    "Deferring duplicate <comment>{$name}</comment>"
-                );
-                $dups[] = $link;
+                $this->logger->info("Adding <comment>{$name}</comment>");
+                $origin[$name] = $link;
             }
         }
-        $state->addDuplicateLinks($type, $dups);
         return $origin;
+    }
+
+    /**
+     * Merge package constraints.
+     *
+     * Adapted from Composer's UpdateCommand::appendConstraintToLink
+     *
+     * @param Link $origin The base package link.
+     * @param Link $merge  The related package link to merge.
+     * @return Link Merged link.
+     */
+    protected function mergeConstraints(Link $origin, Link $merge)
+    {
+        $parser = $this->versionParser;
+        $oldPrettyString = $origin->getConstraint()->getPrettyString();
+        $newPrettyString = $merge->getConstraint()->getPrettyString();
+        if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '>')) {
+            $constraintClass = 'Wikimedia\\Composer\\Merge\\MultiConstraint';
+        } else {
+            $constraintClass = 'Composer\\Semver\\Constraint\\MultiConstraint';
+        }
+        $newConstraint = $constraintClass::create(array(
+            $origin->getConstraint(),
+            $merge->getConstraint()
+        ), true);
+        $newConstraint->setPrettyString($oldPrettyString.', '.$newPrettyString);
+        return new Link(
+            $origin->getSource(),
+            $origin->getTarget(),
+            $newConstraint,
+            $origin->getDescription(),
+            $origin->getPrettyConstraint() . ', ' . $newPrettyString
+        );
     }
 
     /**

--- a/src/Merge/ExtraPackage.php
+++ b/src/Merge/ExtraPackage.php
@@ -62,6 +62,11 @@ class ExtraPackage
     protected $package;
 
     /**
+     * @var array<string, bool> $mergedRequirements
+     */
+    protected $mergedRequirements = array();
+
+    /**
      * @var VersionParser $versionParser
      */
     protected $versionParser;
@@ -101,6 +106,16 @@ class ExtraPackage
     {
         return isset($this->json['extra']['merge-plugin']['require']) ?
             $this->json['extra']['merge-plugin']['require'] : array();
+    }
+
+    /**
+     * Get list of merged requirements from this package.
+     *
+     * @return string[]
+     */
+    public function getMergedRequirements()
+    {
+        return array_keys($this->mergedRequirements);
     }
 
     /**
@@ -292,13 +307,16 @@ class ExtraPackage
 
                 if ($state->replaceDuplicateLinks()) {
                     $this->logger->info("Replacing <comment>{$name}</comment>");
+                    $this->mergedRequirements[$name] = true;
                     $origin[$name] = $link;
                 } else {
                     $this->logger->info("Merging <comment>{$name}</comment>");
+                    $this->mergedRequirements[$name] = true;
                     $origin[$name] = $this->mergeConstraints($origin[$name], $link, $state);
                 }
             } else {
                 $this->logger->info("Adding <comment>{$name}</comment>");
+                $this->mergedRequirements[$name] = true;
                 $origin[$name] = $link;
             }
         }

--- a/src/Merge/MultiConstraint.php
+++ b/src/Merge/MultiConstraint.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of the Composer Merge plugin.
  *
- * Copyright (C) 2015 Bryan Davis, Wikimedia Foundation, and contributors
+ * Copyright (C) 2021 Bryan Davis, Wikimedia Foundation, and contributors
  *
  * This software may be modified and distributed under the terms of the MIT
  * license. See the LICENSE file for details.

--- a/src/Merge/MultiConstraint.php
+++ b/src/Merge/MultiConstraint.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * This file is part of the Composer Merge plugin.
+ *
+ * Copyright (C) 2015 Bryan Davis, Wikimedia Foundation, and contributors
+ *
+ * This software may be modified and distributed under the terms of the MIT
+ * license. See the LICENSE file for details.
+ */
+
+namespace Wikimedia\Composer\Merge;
+
+use Composer\Semver\Constraint\EmptyConstraint;
+use Composer\Semver\Constraint\MultiConstraint as SemverMultiConstraint;
+
+/**
+ * Adapted from Composer's v2 MultiConstraint::create for Composer v1
+ * @author Chauncey McAskill <chauncey@mcaskill.ca>
+ */
+class MultiConstraint extends SemverMultiConstraint
+{
+    /**
+     * Tries to optimize the constraints as much as possible, meaning
+     * reducing/collapsing congruent constraints etc.
+     * Does not necessarily return a MultiConstraint instance if
+     * things can be reduced to a simple constraint
+     *
+     * @param ConstraintInterface[] $constraints A set of constraints
+     * @param bool                  $conjunctive Whether the constraints should be treated as conjunctive or disjunctive
+     *
+     * @return ConstraintInterface
+     */
+    public static function create(array $constraints, $conjunctive = true)
+    {
+        if (0 === \count($constraints)) {
+            return new EmptyConstraint();
+        }
+
+        if (1 === \count($constraints)) {
+            return $constraints[0];
+        }
+
+        $optimized = self::optimizeConstraints($constraints, $conjunctive);
+        if ($optimized !== null) {
+            list($constraints, $conjunctive) = $optimized;
+            if (\count($constraints) === 1) {
+                return $constraints[0];
+            }
+        }
+
+        return new self($constraints, $conjunctive);
+    }
+
+    /**
+     * @return array|null
+     */
+    private static function optimizeConstraints(array $constraints, $conjunctive)
+    {
+        // parse the two OR groups and if they are contiguous we collapse
+        // them into one constraint
+        // [>= 1 < 2] || [>= 2 < 3] || [>= 3 < 4] => [>= 1 < 4]
+        if (!$conjunctive) {
+            $left = $constraints[0];
+            $mergedConstraints = array();
+            $optimized = false;
+            for ($i = 1, $l = \count($constraints); $i < $l; $i++) {
+                $right = $constraints[$i];
+                if ($left instanceof MultiConstraint
+                    && $left->conjunctive
+                    && $right instanceof MultiConstraint
+                    && $right->conjunctive
+                    && ($left0 = (string) $left->constraints[0])
+                    && $left0[0] === '>' && $left0[1] === '='
+                    && ($left1 = (string) $left->constraints[1])
+                    && $left1[0] === '<'
+                    && ($right0 = (string) $right->constraints[0])
+                    && $right0[0] === '>' && $right0[1] === '='
+                    && ($right1 = (string) $right->constraints[1])
+                    && $right1[0] === '<'
+                    && substr($left1, 2) === substr($right0, 3)
+                ) {
+                    $optimized = true;
+                    $left = new MultiConstraint(array_merge(
+                        array(
+                            $left->constraints[0],
+                            $right->constraints[1],
+                        ),
+                        \array_slice($left->constraints, 2),
+                        \array_slice($right->constraints, 2)
+                    ), true);
+                } else {
+                    $mergedConstraints[] = $left;
+                    $left = $right;
+                }
+            }
+            if ($optimized) {
+                $mergedConstraints[] = $left;
+                return array($mergedConstraints, false);
+            }
+        }
+
+        // TODO: Here's the place to put more optimizations
+
+        return null;
+    }
+}
+// vim:sw=4:ts=4:sts=4:et:

--- a/src/Merge/MultiConstraint.php
+++ b/src/Merge/MultiConstraint.php
@@ -1,5 +1,5 @@
 <?php
-// phpcs:ignoreFile
+
 /**
  * This file is part of the Composer Merge plugin.
  *
@@ -18,7 +18,6 @@ use Composer\Semver\Constraint\MultiConstraint as SemverMultiConstraint;
  * Adapted from Composer's v2 MultiConstraint::create for Composer v1
  * @link https://github.com/composer/semver/blob/3.2.4/src/Constraint/MultiConstraint.php
  * @author Chauncey McAskill <chauncey@mcaskill.ca>
- * @codeCoverageIgnore
  */
 class MultiConstraint extends SemverMultiConstraint
 {
@@ -68,8 +67,7 @@ class MultiConstraint extends SemverMultiConstraint
             $optimized = false;
             for ($i = 1, $l = \count($constraints); $i < $l; $i++) {
                 $right = $constraints[$i];
-                if (
-                    $left instanceof SemverMultiConstraint
+                if ($left instanceof SemverMultiConstraint
                     && $left->conjunctive
                     && $right instanceof SemverMultiConstraint
                     && $right->conjunctive
@@ -91,7 +89,8 @@ class MultiConstraint extends SemverMultiConstraint
                             $left->constraints[0],
                             $right->constraints[1],
                         ),
-                        true);
+                        true
+                    );
                 } else {
                     $mergedConstraints[] = $left;
                     $left = $right;

--- a/src/Merge/MultiConstraint.php
+++ b/src/Merge/MultiConstraint.php
@@ -34,11 +34,11 @@ class MultiConstraint extends SemverMultiConstraint
      */
     public static function create(array $constraints, $conjunctive = true)
     {
-        if (0 === \count($constraints)) {
+        if (\count($constraints) === 0) {
             return new EmptyConstraint();
         }
 
-        if (1 === \count($constraints)) {
+        if (\count($constraints) === 1) {
             return $constraints[0];
         }
 

--- a/src/Merge/MultiConstraint.php
+++ b/src/Merge/MultiConstraint.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * This file is part of the Composer Merge plugin.
  *
@@ -15,7 +16,9 @@ use Composer\Semver\Constraint\MultiConstraint as SemverMultiConstraint;
 
 /**
  * Adapted from Composer's v2 MultiConstraint::create for Composer v1
+ * @link https://github.com/composer/semver/blob/3.2.4/src/Constraint/MultiConstraint.php
  * @author Chauncey McAskill <chauncey@mcaskill.ca>
+ * @codeCoverageIgnore
  */
 class MultiConstraint extends SemverMultiConstraint
 {
@@ -65,10 +68,13 @@ class MultiConstraint extends SemverMultiConstraint
             $optimized = false;
             for ($i = 1, $l = \count($constraints); $i < $l; $i++) {
                 $right = $constraints[$i];
-                if ($left instanceof MultiConstraint
+                if (
+                    $left instanceof SemverMultiConstraint
                     && $left->conjunctive
-                    && $right instanceof MultiConstraint
+                    && $right instanceof SemverMultiConstraint
                     && $right->conjunctive
+                    && \count($left->constraints) === 2
+                    && \count($right->constraints) === 2
                     && ($left0 = (string) $left->constraints[0])
                     && $left0[0] === '>' && $left0[1] === '='
                     && ($left1 = (string) $left->constraints[1])
@@ -80,14 +86,12 @@ class MultiConstraint extends SemverMultiConstraint
                     && substr($left1, 2) === substr($right0, 3)
                 ) {
                     $optimized = true;
-                    $left = new MultiConstraint(array_merge(
+                    $left = new MultiConstraint(
                         array(
                             $left->constraints[0],
                             $right->constraints[1],
                         ),
-                        \array_slice($left->constraints, 2),
-                        \array_slice($right->constraints, 2)
-                    ), true);
+                        true);
                 } else {
                     $mergedConstraints[] = $left;
                     $left = $right;

--- a/src/Merge/PluginState.php
+++ b/src/Merge/PluginState.php
@@ -11,6 +11,7 @@
 namespace Wikimedia\Composer\Merge;
 
 use Composer\Composer;
+use Composer\Plugin\PluginInterface;
 
 /**
  * Mutable plugin state
@@ -23,6 +24,11 @@ class PluginState
      * @var Composer $composer
      */
     protected $composer;
+
+    /**
+     * @var bool $isComposer1
+     */
+    protected $isComposer1;
 
     /**
      * @var array $includes
@@ -125,6 +131,17 @@ class PluginState
     public function __construct(Composer $composer)
     {
         $this->composer = $composer;
+        $this->isComposer1 = version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0.0', '<');
+    }
+
+    /**
+     * Test if this plugin runs within Composer 1.
+     *
+     * @return bool
+     */
+    public function isComposer1()
+    {
+        return $this->isComposer1;
     }
 
     /**

--- a/src/Merge/PluginState.php
+++ b/src/Merge/PluginState.php
@@ -35,11 +35,6 @@ class PluginState
     protected $requires = array();
 
     /**
-     * @var array $duplicateLinks
-     */
-    protected $duplicateLinks = array();
-
-    /**
      * @var bool $devMode
      */
     protected $devMode = false;
@@ -304,33 +299,6 @@ class PluginState
     public function shouldOptimizeAutoloader()
     {
         return $this->optimizeAutoloader;
-    }
-
-    /**
-     * Add duplicate packages
-     *
-     * @param string $type Package type
-     * @param array $packages
-     */
-    public function addDuplicateLinks($type, array $packages)
-    {
-        if (!isset($this->duplicateLinks[$type])) {
-            $this->duplicateLinks[$type] = array();
-        }
-        $this->duplicateLinks[$type] =
-            array_merge($this->duplicateLinks[$type], $packages);
-    }
-
-    /**
-     * Get duplicate packages
-     *
-     * @param string $type Package type
-     * @return array
-     */
-    public function getDuplicateLinks($type)
-    {
-        return isset($this->duplicateLinks[$type]) ?
-            $this->duplicateLinks[$type] : array();
     }
 
     /**

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -294,7 +294,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             if ($package === self::PACKAGE_NAME) {
                 $this->logger->info('composer-merge-plugin installed');
                 $this->state->setFirstInstall(true);
-                if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '>')) {
+                if ($this->state->isComposer1()) {
                     $this->state->setLocked(
                         $event->getComposer()->getLocker()->isLocked()
                     );
@@ -319,9 +319,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             $this->state->setFirstInstall(false);
             $this->logger->log("\n".'<info>Running composer update to apply merge settings</info>');
 
-            $isComposer2 = version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '<=');
-
-            if ($isComposer2) {
+            if (!$this->state->isComposer1()) {
                 $file = Factory::getComposerFile();
                 $lock = Factory::getLockFile($file);
                 $lockBackup = file_exists($lock) ? file_get_contents($lock) : null;
@@ -355,7 +353,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
 
             $status = $installer->run();
             if ($status !== 0) {
-                if ($isComposer2 && $lockBackup) {
+                if (!$this->state->isComposer1() && $lockBackup) {
                     $this->logger->log(
                         "\n".'<error>'.
                         'Update to apply merge settings failed, reverting '.$lock.' to its original content.'.

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -292,13 +292,9 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             if ($package === self::PACKAGE_NAME) {
                 $this->logger->info('composer-merge-plugin installed');
                 $this->state->setFirstInstall(true);
-                if ($this->state->isComposer1()) {
-                    $this->state->setLocked(
-                        $event->getComposer()->getLocker()->isLocked()
-                    );
-                } else {
-                    $this->state->setLocked(false);
-                }
+                $this->state->setLocked(
+                    $event->getComposer()->getLocker()->isLocked()
+                );
             }
         }
     }
@@ -347,6 +343,8 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
                 // than just telling the user that composer.json and
                 // composer.lock don't match.
                 $installer->setUpdate(true);
+            } else {
+                $this->logger->log('You may need to manually run composer update to apply merge settings');
             }
 
             $status = $installer->run();

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -20,8 +20,6 @@ use Composer\EventDispatcher\Event as BaseEvent;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Factory;
 use Composer\Installer;
-use Composer\Installer\InstallerEvent;
-use Composer\Installer\InstallerEvents;
 use Composer\Installer\PackageEvent;
 use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -333,11 +333,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
         // @codeCoverageIgnoreStart
         if ($this->state->isFirstInstall()) {
             $this->state->setFirstInstall(false);
-            $this->logger->info(
-                '<comment>' .
-                'Running additional update to apply merge settings' .
-                '</comment>'
-            );
+            $this->logger->log("\n".'<info>Running composer update to apply merge settings</info>');
 
             $config = $this->composer->getConfig();
 

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -371,7 +371,12 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             );
 
             $installer->setUpdate(true);
-            $installer->setUpdateAllowList($requirements);
+
+            if ($this->state->isComposer1()) {
+                $installer->setUpdateWhitelist($requirements);
+            } else {
+                $installer->setUpdateAllowList($requirements);
+            }
 
             $status = $installer->run();
             if ($status !== 0) {

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -982,18 +982,13 @@ class MergePluginTest extends TestCase
         $event->getOperation()->willReturn($operation)->shouldBeCalled();
 
         if ($first) {
-            if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '>')) {
-                $locker = $this->prophesize('Composer\Package\Locker');
-                $locker->isLocked()->willReturn($locked)
-                    ->shouldBeCalled();
-                $this->composer->getLocker()->willReturn($locker->reveal())
-                    ->shouldBeCalled();
-                $event->getComposer()->willReturn($this->composer->reveal())
-                    ->shouldBeCalled();
-            } else {
-                // Always do update in Composer v2
-                $locked = false;
-            }
+            $locker = $this->prophesize('Composer\Package\Locker');
+            $locker->isLocked()->willReturn($locked)
+                ->shouldBeCalled();
+            $this->composer->getLocker()->willReturn($locker->reveal())
+                ->shouldBeCalled();
+            $event->getComposer()->willReturn($this->composer->reveal())
+                ->shouldBeCalled();
         }
 
         $this->fixture->onPostPackageInstall($event->reveal());

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -26,6 +26,7 @@ use Composer\Package\Package;
 use Composer\Package\RootPackage;
 use Composer\Package\Version\VersionParser;
 use Composer\Plugin\PluginEvents;
+use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 use Prophecy\Argument;
@@ -74,11 +75,9 @@ class MergePluginTest extends TestCase
     public function testSubscribedEvents()
     {
         $subscriptions = MergePlugin::getSubscribedEvents();
-        $this->assertEquals(8, count($subscriptions));
-        $this->assertArrayHasKey(
-            InstallerEvents::PRE_DEPENDENCIES_SOLVING,
-            $subscriptions
-        );
+
+        $this->assertEquals(7, count($subscriptions));
+
         $this->assertArrayHasKey(PluginEvents::INIT, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_INSTALL_CMD, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_UPDATE_CMD, $subscriptions);
@@ -145,9 +144,7 @@ class MergePluginTest extends TestCase
 
         $root->getRepositories()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
 
@@ -184,9 +181,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
     /**
@@ -222,9 +217,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
     /**
@@ -261,9 +254,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
     /**
@@ -293,12 +284,10 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+        $this->triggerPlugin($root->reveal(), $dir);
 
         $this->assertArrayHasKey('foo', $packages);
         $this->assertArrayHasKey('monolog/monolog', $packages);
-
-        $this->assertEquals(0, count($extraInstalls));
     }
 
 
@@ -329,12 +318,10 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+        $this->triggerPlugin($root->reveal(), $dir);
 
         $this->assertArrayHasKey('foo', $packages);
         $this->assertArrayNotHasKey('monolog/monolog', $packages);
-
-        $this->assertEquals(0, count($extraInstalls));
     }
 
 
@@ -384,11 +371,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir, $fireInit);
-
-        $this->assertEquals(2, count($extraInstalls));
-        $this->assertEquals('monolog/monolog', $extraInstalls[0][0]);
-        $this->assertEquals('foo', $extraInstalls[1][0]);
+        $this->triggerPlugin($root->reveal(), $dir, $fireInit);
     }
 
 
@@ -418,11 +401,26 @@ class MergePluginTest extends TestCase
                     $args[1]['url']
                 );
 
-                return new \Composer\Repository\VcsRepository(
-                    $args[1],
-                    $io->reveal(),
-                    new \Composer\Config()
-                );
+                $config = new \Composer\Config();
+                $mockIO = $io->reveal();
+                if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '>')) {
+                    return new \Composer\Repository\VcsRepository(
+                        $args[1],
+                        $mockIO,
+                        $config
+                    );
+                } else {
+                    $httpDownloader = new \Composer\Util\HttpDownloader(
+                        $mockIO,
+                        $config
+                    );
+                    return new \Composer\Repository\VcsRepository(
+                        $args[1],
+                        $mockIO,
+                        $config,
+                        $httpDownloader
+                    );
+                }
             }
         );
         $repoManager->prependRepository(Argument::any())->will(
@@ -466,9 +464,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
     /**
@@ -497,11 +493,27 @@ class MergePluginTest extends TestCase
                     $args[1]['url']
                 );
 
-                return new \Composer\Repository\VcsRepository(
-                    $args[1],
-                    $io->reveal(),
-                    new \Composer\Config()
-                );
+                $config = new \Composer\Config();
+                $mockIO = $io->reveal();
+                if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '>')) {
+                    return new \Composer\Repository\VcsRepository(
+                        $args[1],
+                        $mockIO,
+                        $config
+                    );
+                } else {
+                    $httpDownloader = new \Composer\Util\HttpDownloader(
+                        $mockIO,
+                        $config
+                    );
+
+                    return new \Composer\Repository\VcsRepository(
+                        $args[1],
+                        $mockIO,
+                        $config,
+                        $httpDownloader
+                    );
+                }
             }
         );
         $repoManager->prependRepository(Argument::any())->will(
@@ -547,9 +559,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
     /**
@@ -607,9 +617,7 @@ class MergePluginTest extends TestCase
         $root->getSuggests()->shouldNotBeCalled();
         $root->setSuggests(Argument::any())->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir, $fireInit);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir, $fireInit);
     }
 
 
@@ -661,9 +669,8 @@ class MergePluginTest extends TestCase
             }
         )->shouldBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+        $this->triggerPlugin($root->reveal(), $dir);
 
-        $this->assertEquals(0, count($extraInstalls));
         $this->assertEquals(
             array(
                 'psr-4' => array(
@@ -724,9 +731,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir, $fireInit);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir, $fireInit);
     }
 
 
@@ -759,9 +764,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
 
@@ -795,9 +798,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
     /**
@@ -851,9 +852,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
     public function provideDeepMerge()
@@ -897,9 +896,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $scriptsInstalls = $this->triggerPlugin($root->reveal(), $dir, $fireInit);
-
-        $this->assertEquals(0, count($scriptsInstalls));
+        $this->triggerPlugin($root->reveal(), $dir, $fireInit);
     }
 
     /**
@@ -933,9 +930,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
     /**
@@ -971,9 +966,7 @@ class MergePluginTest extends TestCase
         $root->getProvides()->shouldNotBeCalled();
         $root->getSuggests()->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
     /**
@@ -991,17 +984,31 @@ class MergePluginTest extends TestCase
         $event->getOperation()->willReturn($operation)->shouldBeCalled();
 
         if ($first) {
-            $locker = $this->prophesize('Composer\Package\Locker');
-            $locker->isLocked()->willReturn($locked)->shouldBeCalled();
-            $this->composer->getLocker()->willReturn($locker->reveal())
-                ->shouldBeCalled();
-            $event->getComposer()->willReturn($this->composer->reveal())
-                ->shouldBeCalled();
+            if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '>')) {
+                $locker = $this->prophesize('Composer\Package\Locker');
+                $locker->isLocked()->willReturn($locked)
+                    ->shouldBeCalled();
+                $this->composer->getLocker()->willReturn($locker->reveal())
+                    ->shouldBeCalled();
+                $event->getComposer()->willReturn($this->composer->reveal())
+                    ->shouldBeCalled();
+            } else {
+                // Always do update in Composer v2
+                $locked = false;
+            }
         }
 
         $this->fixture->onPostPackageInstall($event->reveal());
-        $this->assertEquals($first, $this->getState()->isFirstInstall());
-        $this->assertEquals($locked, $this->getState()->isLocked());
+        $this->assertEquals(
+            $first,
+            $this->getState()->isFirstInstall(),
+            'Failed assertion on $first argument:'
+        );
+        $this->assertEquals(
+            $locked,
+            $this->getState()->isLocked(),
+            'Failed assertion on $locked argument:'
+        );
     }
 
 
@@ -1043,11 +1050,27 @@ class MergePluginTest extends TestCase
             Argument::type('string'),
             Argument::type('array')
         )->will(function ($args) use ($that, $io) {
-            return new \Composer\Repository\VcsRepository(
-                $args[1],
-                $io->reveal(),
-                new \Composer\Config()
-            );
+            $config = new \Composer\Config();
+            $mockIO = $io->reveal();
+            if (version_compare('2.0.0', PluginInterface::PLUGIN_API_VERSION, '>')) {
+                return new \Composer\Repository\VcsRepository(
+                    $args[1],
+                    $mockIO,
+                    $config
+                );
+            } else {
+                $httpDownloader = new \Composer\Util\HttpDownloader(
+                    $mockIO,
+                    $config
+                );
+
+                return new \Composer\Repository\VcsRepository(
+                    $args[1],
+                    $mockIO,
+                    $config,
+                    $httpDownloader
+                );
+            }
         });
         $repoManager->prependRepository(Argument::any())->shouldBeCalled();
         $this->composer->getRepositoryManager()->will(
@@ -1132,7 +1155,8 @@ class MergePluginTest extends TestCase
                 );
             }
         );
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
 
@@ -1173,8 +1197,7 @@ class MergePluginTest extends TestCase
             }
         );
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
     /**
@@ -1217,8 +1240,7 @@ class MergePluginTest extends TestCase
             }
         );
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir, $fireInit);
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir, $fireInit);
     }
 
 
@@ -1263,7 +1285,8 @@ class MergePluginTest extends TestCase
                 );
             }
         );
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
 
@@ -1290,8 +1313,7 @@ class MergePluginTest extends TestCase
         $root->setDevRequires(Argument::type('array'))->shouldNotBeCalled();
         $root->setRepositories(Argument::type('array'))->shouldNotBeCalled();
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
 
@@ -1322,9 +1344,7 @@ class MergePluginTest extends TestCase
             }
         );
 
-        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
-
-        $this->assertEquals(0, count($extraInstalls));
+        $this->triggerPlugin($root->reveal(), $dir);
     }
 
 
@@ -1403,7 +1423,7 @@ class MergePluginTest extends TestCase
      * @param RootPackage $package
      * @param string $directory Working directory for composer run
      * @param bool $fireInit Should the init event should be triggered?
-     * @return array Constrains added by MergePlugin::onDependencySolve
+     * @return void
      */
     protected function triggerPlugin($package, $directory, $fireInit = false)
     {
@@ -1427,28 +1447,6 @@ class MergePluginTest extends TestCase
         );
         $this->fixture->onInstallUpdateOrDump($event);
 
-        $requestInstalls = array();
-        $request = $this->prophesize('Composer\DependencyResolver\Request');
-        $request->install(Argument::any(), Argument::any())->will(
-            function ($args) use (&$requestInstalls) {
-                $requestInstalls[] = $args;
-            }
-        );
-
-        $event = new InstallerEvent(
-            InstallerEvents::PRE_DEPENDENCIES_SOLVING,
-            $this->composer->reveal(),
-            $this->io->reveal(),
-            true, //dev mode
-            $this->prophesize('Composer\DependencyResolver\PolicyInterface')->reveal(),
-            $this->prophesize('Composer\DependencyResolver\Pool')->reveal(),
-            $this->prophesize('Composer\Repository\CompositeRepository')->reveal(),
-            $request->reveal(),
-            array()
-        );
-
-        $this->fixture->onDependencySolve($event);
-
         $event = new Event(
             ScriptEvents::PRE_AUTOLOAD_DUMP,
             $this->composer->reveal(),
@@ -1468,8 +1466,6 @@ class MergePluginTest extends TestCase
             array()
         );
         $this->fixture->onPostInstallOrUpdate($event);
-
-        return $requestInstalls;
     }
 
     /**

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -15,8 +15,6 @@ use Wikimedia\Composer\Merge\PluginState;
 
 use Composer\Composer;
 use Composer\DependencyResolver\Operation\InstallOperation;
-use Composer\Installer\InstallerEvent;
-use Composer\Installer\InstallerEvents;
 use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
 use Composer\Package\BasePackage;


### PR DESCRIPTION
Latest Update 2021-01-25 14:25 EST

**Notes**:

1. Avoid unnecessary issue bumping. Please test this pull request and report issues or approve working state.  
   See [comment](https://github.com/wikimedia/composer-merge-plugin/pull/189#issuecomment-731199112).
2. Stability of this pull request's changeset needs additional testing from the community, such as unintentional updates upon requiring this plugin.  
   See [comment](https://github.com/wikimedia/composer-merge-plugin/pull/189#issuecomment-728452368).
3. Project is stuck in the process of transferring ownership to a new team within the Wikimedia Foundation.  
   See [comment](https://github.com/wikimedia/composer-merge-plugin/pull/189#issuecomment-728375965).
4. Since v1.4 of the plugin does not support Composer v2, the plugin is ignored when updating to v1.5. As a result, Composer is unaware of the merged dependencies and removes them. Either update the plugin with Composer v1 first or run `composer update` again.  
  See [comment](https://github.com/wikimedia/composer-merge-plugin/pull/189#issuecomment-741624930).
5. Unintentional lock file updates caused by `isFirstInstall()` on Composer v2. Listening only to `post-update-cmd` instead of `post-install-cmd` might be more sensible.
  See [comment](https://github.com/wikimedia/composer-merge-plugin/pull/189#issuecomment-754740823) and followup.
6. Please be patient, we don't want to push broken changes.

**How to test**:

```json
{
    "repositories": [
        {
            "type":"vcs",
            "url":"https://github.com/mcaskill/composer-merge-plugin"
        }
    ],
    "require": {
        "wikimedia/composer-merge-plugin": "dev-feature/composer-v2 as 1.5.0"
    }
}
```

---

**Tasks**:

- [x] Find alternative to install inherited dependencies without affecting locked dependencies.  
  See [comment \#1](https://github.com/wikimedia/composer-merge-plugin/pull/189#discussion_r516207055), [comment \#2](https://github.com/wikimedia/composer-merge-plugin/pull/189#issuecomment-741013328), [comment \#3](https://github.com/wikimedia/composer-merge-plugin/pull/189#issuecomment-741624930).
- [x] Rebase to include #197 and #199
- [x] Update port of `MultiConstraint` to latest version of composer/semver.  
  See [comment](https://github.com/wikimedia/composer-merge-plugin/pull/189#discussion_r526385147).
- [x] Method `Factory::getLockFile()` does not exist in Composer 1.  
  See [comment](https://github.com/wikimedia/composer-merge-plugin/pull/189#discussion_r516205524).

---

Replaces #187, #185, as fix for #184 (as per composer/composer#8726)

I've tested using the example and the unit tests and it works in Composer v1 and v2.

This alternative proposal forgoes `PRE_DEPENDENCIES_SOLVING` entirely to avoid over-complicating the codebase and streamline the plugin's merge logic.

The issue with the previous attempts (as well as attempts on other plugins) stems from a miscommunication from the Composer team of the major difference in how v1 and v2 resolve and install dependencies.

> […] Roughly speaking:
> 
> - Composer v1: Composer resolves dependencies (dispatching `*_DEPENDENCIES_SOLVING`), iterates packages (while dispatching `PRE_PACKAGE_*` before `PRE_FILE_DOWNLOAD`), then finally writes the lock file.
> - Composer v2: Composer resolves dependencies (dispatching `PRE_POOL_CREATE`), writes the lock file, dispatches `PRE_OPERATIONS_EXEC`, downloads the packages (while dispatching `PRE_FILE_DOWNLOAD`), then iterates packages (while dispatching `PRE_PACKAGE_*`).
> 
> In particular, people are assuming that `PRE_OPERATIONS_EXEC` is a replacement for `PRE_DEPENDENCIES_SOLVING` since they are dispatched in a similar-looking routine. The closest event to the latter would actually be `PRE_POOL_CREATE`.
— [composer/composer#8726](https://github.com/composer/composer/issues/8726#issuecomment-699657360)

Back to my proposal.

Currently, the use of `PRE_DEPENDENCIES_SOLVING` in the plugin is used to inject duplicate requirements (usually with a different version constraints) into the solver (while distinguishing between `require` and `require-dev`).

What I propose replaces the duplicate links tracking in `ExtraPackage` by back porting Composer 2's new static `MultiConstraint::create()` method which can be used to resolve complex-constraints early on. In turn, this makes the need for `PRE_DEPENDENCIES_SOLVING` obsolete.

I hope this PR will, at the very least, help to figure out how to support Composer v2.