### PR TITLE
Fix namespace check define constant class

### DIFF
--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -151,7 +151,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        if (defined('InstallerEvents::PRE_OPERATIONS_EXEC')) {
+        if (defined('\Composer\Installer\InstallerEvents::PRE_OPERATIONS_EXEC')) {
             // composer-plugin-api ^2.0
             $installerStartEvent = InstallerEvents::PRE_OPERATIONS_EXEC;
         } else {


### PR DESCRIPTION
Solves the undefined constant problem, as you need to enter the full namespace in the string.

`Fatal error: Uncaught Error: Undefined class constant 'PRE_DEPENDENCIES_SOLVING' in vendor/wikimedia/composer-merge-plugin/src/MergePlugin.php:159`

https://github.com/wikimedia/composer-merge-plugin/issues/184