### PR TITLE
Work around Composer multi-version loading hack using a "V2" namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
     },
     "autoload": {
         "psr-4": {
-            "Wikimedia\\Composer\\": "src/"
+            "Wikimedia\\Composer\\Merge\\V2\\": "src/"
         }
     },
     "extra": {
         "branch-alias": {
             "dev-master": "1.5.x-dev"
         },
-        "class": "Wikimedia\\Composer\\MergePlugin"
+        "class": "Wikimedia\\Composer\\Merge\\V2\\MergePlugin"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.5.x-dev"
+             "dev-master": "2.x-dev"
         },
         "class": "Wikimedia\\Composer\\Merge\\V2\\MergePlugin"
     },

--- a/src/ExtraPackage.php
+++ b/src/ExtraPackage.php
@@ -342,9 +342,9 @@ class ExtraPackage
         $newPrettyString = $merge->getConstraint()->getPrettyString();
 
         if ($state->isComposer1()) {
-            $constraintClass = 'Wikimedia\\Composer\\Merge\\V2\\MultiConstraint';
+            $constraintClass = MultiConstraint::class;
         } else {
-            $constraintClass = 'Composer\\Semver\\Constraint\\MultiConstraint';
+            $constraintClass = \Composer\Semver\Constraint\MultiConstraint::class;
 
             if (Intervals::isSubsetOf($origin->getConstraint(), $merge->getConstraint())) {
                 return $origin;

--- a/src/ExtraPackage.php
+++ b/src/ExtraPackage.php
@@ -8,9 +8,7 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer\Merge;
-
-use Wikimedia\Composer\Logger;
+namespace Wikimedia\Composer\Merge\V2;
 
 use Composer\Composer;
 use Composer\Json\JsonFile;
@@ -22,8 +20,6 @@ use Composer\Package\RootAliasPackage;
 use Composer\Package\RootPackage;
 use Composer\Package\RootPackageInterface;
 use Composer\Package\Version\VersionParser;
-use Composer\Plugin\PluginInterface;
-use Composer\Semver\Constraint\MultiConstraint as SemverMultiConstraint;
 use Composer\Semver\Intervals;
 use UnexpectedValueException;
 
@@ -346,7 +342,7 @@ class ExtraPackage
         $newPrettyString = $merge->getConstraint()->getPrettyString();
 
         if ($state->isComposer1()) {
-            $constraintClass = 'Wikimedia\\Composer\\Merge\\MultiConstraint';
+            $constraintClass = 'Wikimedia\\Composer\\Merge\\V2\\MultiConstraint';
         } else {
             $constraintClass = 'Composer\\Semver\\Constraint\\MultiConstraint';
 

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -8,7 +8,7 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer;
+namespace Wikimedia\Composer\Merge\V2;
 
 use Composer\IO\IOInterface;
 

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -8,11 +8,7 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer;
-
-use Wikimedia\Composer\Merge\ExtraPackage;
-use Wikimedia\Composer\Merge\MissingFileException;
-use Wikimedia\Composer\Merge\PluginState;
+namespace Wikimedia\Composer\Merge\V2;
 
 use Composer\Composer;
 use Composer\DependencyResolver\Operation\InstallOperation;

--- a/src/MissingFileException.php
+++ b/src/MissingFileException.php
@@ -8,7 +8,7 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer\Merge;
+namespace Wikimedia\Composer\Merge\V2;
 
 /**
  * @author Bryan Davis <bd808@bd808.com>

--- a/src/MultiConstraint.php
+++ b/src/MultiConstraint.php
@@ -9,7 +9,7 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer\Merge;
+namespace Wikimedia\Composer\Merge\V2;
 
 use Composer\Semver\Constraint\EmptyConstraint;
 use Composer\Semver\Constraint\MultiConstraint as SemverMultiConstraint;

--- a/src/NestedArray.php
+++ b/src/NestedArray.php
@@ -8,7 +8,7 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer\Merge;
+namespace Wikimedia\Composer\Merge\V2;
 
 /**
  * Adapted from

--- a/src/PluginState.php
+++ b/src/PluginState.php
@@ -8,7 +8,7 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer\Merge;
+namespace Wikimedia\Composer\Merge\V2;
 
 use Composer\Composer;
 use Composer\Plugin\PluginInterface;

--- a/src/StabilityFlags.php
+++ b/src/StabilityFlags.php
@@ -8,7 +8,7 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer\Merge;
+namespace Wikimedia\Composer\Merge\V2;
 
 use Composer\Package\BasePackage;
 use Composer\Package\Version\VersionParser;

--- a/tests/phpunit/LoggerTest.php
+++ b/tests/phpunit/LoggerTest.php
@@ -8,14 +8,13 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer;
+namespace Wikimedia\Composer\Merge\V2;
 
-use Composer\IO\IOInterface;
 use Prophecy\Argument;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Wikimedia\Composer\Logger
+ * @covers \Wikimedia\Composer\Merge\V2\Logger
  */
 class LoggerTest extends TestCase
 {

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -8,10 +8,7 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer;
-
-use Wikimedia\Composer\Merge\ExtraPackage;
-use Wikimedia\Composer\Merge\PluginState;
+namespace Wikimedia\Composer\Merge\V2;
 
 use Composer\Composer;
 use Composer\DependencyResolver\Operation\InstallOperation;
@@ -32,12 +29,12 @@ use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
 /**
- * @covers Wikimedia\Composer\Logger
- * @covers Wikimedia\Composer\Merge\ExtraPackage
- * @covers Wikimedia\Composer\Merge\NestedArray
- * @covers Wikimedia\Composer\Merge\PluginState
- * @covers Wikimedia\Composer\Merge\StabilityFlags
- * @covers Wikimedia\Composer\MergePlugin
+ * @covers \Wikimedia\Composer\Merge\V2\Logger
+ * @covers \Wikimedia\Composer\Merge\V2\ExtraPackage
+ * @covers \Wikimedia\Composer\Merge\V2\NestedArray
+ * @covers \Wikimedia\Composer\Merge\V2\PluginState
+ * @covers \Wikimedia\Composer\Merge\V2\StabilityFlags
+ * @covers \Wikimedia\Composer\Merge\V2\MergePlugin
  */
 class MergePluginTest extends TestCase
 {
@@ -1313,7 +1310,7 @@ class MergePluginTest extends TestCase
     public function testMissingRequireThrowsException()
     {
         $dir = $this->fixtureDir(__FUNCTION__);
-        $this->expectException(\Wikimedia\Composer\Merge\MissingFileException::class);
+        $this->expectException(MissingFileException::class);
         $root = $this->rootFromJson("{$dir}/composer.json");
         $root->getRequires()->shouldNotBeCalled();
         $root->getDevRequires()->shouldNotBeCalled();

--- a/tests/phpunit/NestedArrayTest.php
+++ b/tests/phpunit/NestedArrayTest.php
@@ -8,13 +8,13 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer\Merge;
+namespace Wikimedia\Composer\Merge\V2;
 
 use Composer\Composer;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @coversDefaultClass Wikimedia\Composer\Merge\NestedArray
+ * @coversDefaultClass \Wikimedia\Composer\Merge\V2\NestedArray
  */
 class NestedArrayTest extends TestCase
 {

--- a/tests/phpunit/PluginStateTest.php
+++ b/tests/phpunit/PluginStateTest.php
@@ -8,13 +8,13 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer\Merge;
+namespace Wikimedia\Composer\Merge\V2;
 
 use Composer\Composer;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Wikimedia\Composer\Merge\PluginState
+ * @covers \Wikimedia\Composer\Merge\V2\PluginState
  */
 class PluginStateTest extends TestCase
 {

--- a/tests/phpunit/StabilityFlagsTest.php
+++ b/tests/phpunit/StabilityFlagsTest.php
@@ -8,13 +8,13 @@
  * license. See the LICENSE file for details.
  */
 
-namespace Wikimedia\Composer\Merge;
+namespace Wikimedia\Composer\Merge\V2;
 
 use Composer\Package\BasePackage;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Wikimedia\Composer\Merge\StabilityFlags
+ * @covers \Wikimedia\Composer\Merge\V2\StabilityFlags
  */
 class StabilityFlagsTest extends TestCase
 {


### PR DESCRIPTION
Composer would try to load two versions of the same plugin, by reading the main plugin file and rewriting the class name. But this doesn't work if the plugin has multiple classes. It tries to run the new plugin class with old helper classes.

So:

* Move all classes to Wikimedia\Composer\Merge\V2. This includes classes that were previously in the parent namespace.
* Clean up unused "use" statements.

Note that the namespace version number will have to be incremented every time there is an internal interface change.

Closes #205