### PR TITLE
build: Use php and composer from debian packages

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,4 +1,4 @@
-name: PHP Composer
+name: CI
 
 on:
   push:
@@ -6,53 +6,56 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version:
-          - "7.2"
-          - "7.3"
-          - "7.4"
-          - "8.0"
-        composer-dependencies:
-          - 'highest'
+        include:
+          # Includes php7.1-8.0, composer 2, php-xdebug, and more
+          # https://github.com/actions/virtual-environments/blob/ubuntu18/20210318.0/images/linux/Ubuntu1804-README.md#php
+          - os: ubuntu-18.04
+            php: "7.2"
+          - os: ubuntu-18.04
+            php: "7.3"
+          # Includes php7.4-8.x, composer 2, php-xdebug, and more
+          # https://github.com/actions/virtual-environments/blob/ubuntu20/20210318.0/images/linux/Ubuntu2004-README.md#php
+          - os: ubuntu-20.04
+            php: "7.4"
+          - os: ubuntu-20.04
+            php: "8.0"
+
+    name: Test PHP ${{ matrix.php }}
+    runs-on: ${{ matrix.os }}
     env:
       COMPOSER_DISABLE_XDEBUG_WARN: 1
 
-    name: Test PHP ${{ matrix.php-version }}
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup PHP version
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-version }}
-        extensions: ast
-        coverage: xdebug
-        tools: composer:v2
+    - name: Use PHP ${{ matrix.php }}
+      run: |
+        sudo update-alternatives --set php /usr/bin/php${{ matrix.php }}
+        sudo apt-add-repository ppa:ondrej/php -y
+        sudo apt-fast install -y --no-install-recommends php${{ matrix.php }}-ast
 
-    - name: Test Composer v1
+    - name: Use Composer v1
       run: composer require --dev --no-update composer/composer:^1.1
 
-    - uses: "ramsey/composer-install@v1"
-      with:
-        dependency-versions: "${{ matrix.composer-dependencies }}"
+    - name: composer install
+      run: composer update --no-interaction --no-progress --ansi
 
     - run: composer test
 
-    - name: Test Composer v2
+    - name: Use Composer v2
       run: composer require --dev --no-update composer/composer:^2.0
 
-    - uses: "ramsey/composer-install@v1"
-      with:
-        dependency-versions: "${{ matrix.composer-dependencies }}"
+    - name: composer install
+      run: composer update --no-interaction --no-progress --ansi
 
     - run: composer test
     - run: composer phan
 
   ocular-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     if: ${{ success() }} && github.repository == 'wikimedia/composer-merge-plugin'
     needs: [run]
 
@@ -60,24 +63,24 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup PHP version for coverage
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: "7.2"
-        coverage: xdebug
-        tools: composer:v1
+    - name: Use PHP 7.2
+      run: sudo update-alternatives --set php /usr/bin/php7.2
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress
 
     - name: Run coverage
       run: composer coverage
+      env:
+        XDEBUG_MODE: coverage
 
     - name: Get Ocular
       run: wget https://scrutinizer-ci.com/ocular.phar
+      continue-on-error: true
 
     - name: Upload code coverage
       run: php ocular.phar code-coverage:upload --format=php-clover reports/coverage.xml
+      continue-on-error: true
 
 #  irc-push:
 #    runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Latest Stable Version]](https://packagist.org/packages/wikimedia/composer-merge-plugin) [![License]](https://github.com/wikimedia/composer-merge-plugin/blob/master/LICENSE)
-[![Build Status]](https://github.com/wikimedia/composer-merge-plugin/actions)
+[![Build Status]](https://github.com/wikimedia/composer-merge-plugin/actions/workflows/CI.yaml)
 [![Code Coverage]](https://scrutinizer-ci.com/g/wikimedia/composer-merge-plugin/?branch=master)
 
 Composer Merge Plugin
@@ -239,6 +239,6 @@ Composer Merge plugin is licensed under the MIT license. See the
 [PHP Code Sniffer]: http://pear.php.net/package/PHP_CodeSniffer
 [Latest Stable Version]: https://img.shields.io/packagist/v/wikimedia/composer-merge-plugin.svg?style=flat
 [License]: https://img.shields.io/packagist/l/wikimedia/composer-merge-plugin.svg?style=flat
-[Build Status]: https://img.shields.io/github/workflow/status/wikimedia/composer-merge-plugin/PHP%20Composer/master?style=flat
+[Build Status]: https://github.com/wikimedia/composer-merge-plugin/actions/workflows/CI.yaml/badge.svg
 [Code Coverage]: https://img.shields.io/scrutinizer/coverage/g/wikimedia/composer-merge-plugin/master.svg?style=flat
 [custom commands]: https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands


### PR DESCRIPTION
GitHub's base images have all the modern php versions pre-installed (as php7.1, php7.2, etc., Debian-style), including composer, xdebug and most anything else we need.

Use that directly, instead of various complex third-party docker and [Webpack-compiled Node.js scripts](https://github.com/shivammathur/setup-php/blob/2.10.0/dist/index.js) (?) to install other novel PHP binaries, and run-time downloading composer, with each step running in a different container with different packages present.

Runtime from last build before this commit
<https://github.com/wikimedia/composer-merge-plugin/actions/runs/638619206>
> Test PHP 7.2 1m 59s   |
> Test PHP 7.3 1m 42s   | =>  ocular-push 1m 35s
> Test PHP 7.4 1m 17s   |
> Test PHP 8.0 1m 5s    |

Runtime from one the builds for this commit:
<https://github.com/wikimedia/composer-merge-plugin/actions/runs/731586116>
> Test PHP 7.2 31s   |
> Test PHP 7.3 33s   | =>  ocular-push 14s
> Test PHP 7.4 37s   |
> Test PHP 8.0 32s   |