### PR TITLE
Re-write relative paths for fields when recursing

### DIFF
--- a/src/ExtraPackage.php
+++ b/src/ExtraPackage.php
@@ -89,7 +89,8 @@ class ExtraPackage
      */
     public function getIncludes()
     {
-        return $this->json['extra']['merge-plugin']['include'] ?? [];
+        return isset($this->json['extra']['merge-plugin']['include']) ?
+            $this->fixRelativePaths($this->json['extra']['merge-plugin']['include']) : [];
     }
 
     /**
@@ -99,7 +100,8 @@ class ExtraPackage
      */
     public function getRequires()
     {
-        return $this->json['extra']['merge-plugin']['require'] ?? [];
+        return isset($this->json['extra']['merge-plugin']['require']) ?
+            $this->fixRelativePaths($this->json['extra']['merge-plugin']['require']) : [];
     }
 
     /**
@@ -217,6 +219,9 @@ class ExtraPackage
         foreach ($this->json['repositories'] as $repoJson) {
             if (!isset($repoJson['type'])) {
                 continue;
+            }
+            if ($repoJson['type'] == 'path' && isset($repoJson['url'])) {
+                $repoJson['url'] = $this->fixRelativePaths(array($repoJson['url']))[0];
             }
             $this->logger->info("Prepending {$repoJson['type']} repository");
             $repo = $repoManager->createRepository(

--- a/tests/phpunit/fixtures/testRecursiveIncludesWithSubDirectory/composer.json
+++ b/tests/phpunit/fixtures/testRecursiveIncludesWithSubDirectory/composer.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "subdirectory/composer.local.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveIncludesWithSubDirectory/subdirectory/composer.local.2.json
+++ b/tests/phpunit/fixtures/testRecursiveIncludesWithSubDirectory/subdirectory/composer.local.2.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "monolog/monolog": "~1.0"
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveIncludesWithSubDirectory/subdirectory/composer.local.json
+++ b/tests/phpunit/fixtures/testRecursiveIncludesWithSubDirectory/subdirectory/composer.local.json
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "foo": "1.0.0"
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "composer.local.2.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursivePathRepositoriesWithSubDirectory/composer.json
+++ b/tests/phpunit/fixtures/testRecursivePathRepositoriesWithSubDirectory/composer.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "subdirectory/composer.local.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursivePathRepositoriesWithSubDirectory/subdirectory/composer.local.2.json
+++ b/tests/phpunit/fixtures/testRecursivePathRepositoriesWithSubDirectory/subdirectory/composer.local.2.json
@@ -1,0 +1,11 @@
+{
+	"require": {
+		"wikimedia/composer-merge-plugin": "dev-master#deadbeef"
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "local/directory"
+		}
+	]
+}

--- a/tests/phpunit/fixtures/testRecursivePathRepositoriesWithSubDirectory/subdirectory/composer.local.json
+++ b/tests/phpunit/fixtures/testRecursivePathRepositoriesWithSubDirectory/subdirectory/composer.local.json
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "foo": "1.0.0"
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "composer.local.2.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveRequires/composer.json
+++ b/tests/phpunit/fixtures/testRecursiveRequires/composer.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "require": [
+                "composer.local.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveRequires/composer.local.2.json
+++ b/tests/phpunit/fixtures/testRecursiveRequires/composer.local.2.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "monolog/monolog": "~1.0"
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveRequires/composer.local.json
+++ b/tests/phpunit/fixtures/testRecursiveRequires/composer.local.json
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "foo": "1.0.0"
+    },
+    "extra": {
+        "merge-plugin": {
+            "require": [
+                "composer.local.2.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveRequiresWithSubDirectory/composer.json
+++ b/tests/phpunit/fixtures/testRecursiveRequiresWithSubDirectory/composer.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "require": [
+                "subdirectory/composer.local.json"
+            ]
+        }
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveRequiresWithSubDirectory/subdirectory/composer.local.2.json
+++ b/tests/phpunit/fixtures/testRecursiveRequiresWithSubDirectory/subdirectory/composer.local.2.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "monolog/monolog": "~1.0"
+    }
+}

--- a/tests/phpunit/fixtures/testRecursiveRequiresWithSubDirectory/subdirectory/composer.local.json
+++ b/tests/phpunit/fixtures/testRecursiveRequiresWithSubDirectory/subdirectory/composer.local.json
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "foo": "1.0.0"
+    },
+    "extra": {
+        "merge-plugin": {
+            "require": [
+                "composer.local.2.json"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This affects the fields:
 - "required",
 - "include", and
 - "path repository"

Added test cases for each.

Re-based and updated version of #160.

Fixes #161.
