### PR TITLE
Propagate exit code when running post-install hook

### DIFF
--- a/src/ExtraPackage.php
+++ b/src/ExtraPackage.php
@@ -333,7 +333,7 @@ class ExtraPackage
      * Adapted from Composer's UpdateCommand::appendConstraintToLink
      *
      * @param Link $origin The base package link.
-     * @param Link $merge  The related package link to merge.
+     * @param Link $merge The related package link to merge.
      * @param PluginState $state
      * @return Link Merged link.
      */
@@ -437,7 +437,7 @@ class ExtraPackage
     }
 
     /**
-     * Merge package links of the given type  into a RootPackageInterface
+     * Merge package links of the given type into a RootPackageInterface
      *
      * @param string $type 'conflict', 'replace' or 'provide'
      * @param RootPackageInterface $root


### PR DESCRIPTION
This is related to #180. 

We have noticed that when post-install hook is executed composer-merge-plugin executed the whole process again and when that fails it just logs an error and does not propagate exit status code to the parent process causing composer to return exit status code 0 even when the process clearly failed.
This change should propagate exit status code and will help preventing broken builds in CI/CD environments when tooling reiles on exit status codes to determine if the command finished successfully or not.