### PR TITLE
Remove deprecation warnings for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "mediawiki/mediawiki-phan-config": "0.11.1",
         "php-parallel-lint/php-parallel-lint": "~1.3.1",
         "phpspec/prophecy": "~1.15.0",
+        "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^8.5||^9.0",
         "squizlabs/php_codesniffer": "~3.7.1"
     },

--- a/tests/phpunit/LoggerTest.php
+++ b/tests/phpunit/LoggerTest.php
@@ -13,12 +13,14 @@ namespace Wikimedia\Composer\Merge\V2;
 use Composer\IO\IOInterface;
 use Prophecy\Argument;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Wikimedia\Composer\Merge\V2\Logger
  */
 class LoggerTest extends TestCase
 {
+    use ProphecyTrait;
 
     public function testVeryVerboseDebug()
     {

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -34,6 +34,7 @@ use Composer\Script\ScriptEvents;
 use Composer\Util\HttpDownloader;
 use Prophecy\Argument;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionClass;
 use ReflectionProperty;
@@ -48,6 +49,7 @@ use ReflectionProperty;
  */
 class MergePluginTest extends TestCase
 {
+    use ProphecyTrait;
 
     /**
      * @var Composer
@@ -1622,7 +1624,7 @@ class MergePluginTest extends TestCase
     {
         return [
             "with INIT event" => [true],
-            "without INIT event" => [true],
+            "without INIT event" => [false],
         ];
     }
 

--- a/tests/phpunit/NestedArrayTest.php
+++ b/tests/phpunit/NestedArrayTest.php
@@ -12,12 +12,15 @@ namespace Wikimedia\Composer\Merge\V2;
 
 use Composer\Composer;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @coversDefaultClass \Wikimedia\Composer\Merge\V2\NestedArray
  */
 class NestedArrayTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @covers ::mergeDeep
      * @covers ::mergeDeepArray

--- a/tests/phpunit/PluginStateTest.php
+++ b/tests/phpunit/PluginStateTest.php
@@ -12,12 +12,14 @@ namespace Wikimedia\Composer\Merge\V2;
 
 use Composer\Composer;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Wikimedia\Composer\Merge\V2\PluginState
  */
 class PluginStateTest extends TestCase
 {
+    use ProphecyTrait;
 
     public function testLocked()
     {

--- a/tests/phpunit/StabilityFlagsTest.php
+++ b/tests/phpunit/StabilityFlagsTest.php
@@ -13,12 +13,14 @@ namespace Wikimedia\Composer\Merge\V2;
 use Composer\Package\BasePackage;
 use Composer\Package\Link;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \Wikimedia\Composer\Merge\V2\StabilityFlags
  */
 class StabilityFlagsTest extends TestCase
 {
+    use ProphecyTrait;
 
     /**
      * @dataProvider provideExplicitStability


### PR DESCRIPTION
Solves the warning "PHPUnit\Framework\TestCase::prophesize() is deprecated and will be removed in PHPUnit 10. Please use the trait provided by phpspec/prophecy-phpunit" that appears when running tests.

Also let provideFireInit actually provide distinct data.