### PR TITLE
Don't include composer files already required by root package

### DIFF
--- a/src/ExtraPackage.php
+++ b/src/ExtraPackage.php
@@ -115,6 +115,16 @@ class ExtraPackage
     }
 
     /**
+     * Get the name of this package
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->json['name'];
+    }
+
+    /**
      * Read the contents of a composer.json style file into an array.
      *
      * The package contents are fixed up to be usable to create a Package

--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -270,6 +270,13 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
 
         $package = new ExtraPackage($path, $this->composer, $this->logger);
 
+        if (isset($root->getRequires()[$package->getName()])) {
+            $this->logger->info(
+                "Ignoring composer json already required by root: <comment>{$package->getName()}</comment>"
+            );
+            return;
+        }
+
         if (isset($this->loadedNoDev[$path])) {
             $this->logger->info(
                 "Loading -dev sections of <comment>{$path}</comment>..."


### PR DESCRIPTION
This solves several issues, including but not limited to the following:
Make a `composer.json` similar to this:
```json
{
    "require": {
        "wikimedia/composer-merge-plugin": "dev-master"
    },
    "extra": {
        "merge-plugin": {
            "include": [
                "composer.local.json",
                "extensions/*/composer.json"
            ],
            "recurse": true
        }
    }
}
```

With this set up, the following `composer.local.json`s give problems:
```json
{
  "require": {
    "mediawiki/user-functions": "dev-REL1_35"
  },
  "extra": {
    "merge-plugin": {
      "include": [
        "extensions/*/composer.json"
      ]
    }
  }
}
```
Gives the error `Fatal error: Cannot redeclare <some function/class> (previously declared in <directory>/extensions/<name>/<file>:<line>) in <directory>/extensions/<name>/<file> on line <line>`, as described in [this issue on this repo](https://github.com/wikimedia/composer-merge-plugin/issues/247) and [this issue in the composer repo](https://github.com/composer/composer/issues/11102)

```json
{
    "require": {
        "mediawiki/semantic-media-wiki": "3.2.3"
    },
    "extra": {
        "merge-plugin": {
            "include": [
                "extensions/*/composer.json"
            ]
        }
    }
}
```
Gives the error
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - my/root-package is present at version 1.0.0 and cannot be modified by Composer
    - mediawiki/semantic-media-wiki[3.2.3] cannot be installed as that would require removing my/root-package[1.0.0]. They both replace mediawiki/semantic-mediawiki and thus cannot coexist.
    - Root composer.json requires mediawiki/semantic-media-wiki 3.2.3 -> satisfiable by mediawiki/semantic-media-wiki[3.2.3].
```
which is also discussed in [this issue on this repo](https://github.com/wikimedia/composer-merge-plugin/issues/221) (Which also says "[..] it would be good if there was some way to indicate not to merge the configs of any packages that are already included by the main composer.json file since their configs will already be evaluated by Composer when they're required in the main composer.json file.", which is what this pull request does). Solving the issue by using the `merge-replace: false` option gives the same `Fatal error: Cannot redeclare` problem described above.

This pull request solves all these issues.