### PR TITLE
Expose dev dependencies to "composer depends" command

### DIFF
--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -81,9 +81,10 @@ class MergePluginTest extends TestCase
     {
         $subscriptions = MergePlugin::getSubscribedEvents();
 
-        $this->assertCount(7, $subscriptions);
+        $this->assertCount(8, $subscriptions);
 
         $this->assertArrayHasKey(PluginEvents::INIT, $subscriptions);
+        $this->assertArrayHasKey(PluginEvents::COMMAND, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_INSTALL_CMD, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_UPDATE_CMD, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_AUTOLOAD_DUMP, $subscriptions);


### PR DESCRIPTION
Currently, `composer depends` does not know about dev dependencies coming from a merge, which can be confusing.
This PR exposes these dependencies to the depends command.