### PR TITLE
do not update on install

### DIFF
--- a/src/MergePlugin.php
+++ b/src/MergePlugin.php
@@ -157,8 +157,6 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
                 ['onInit', self::CALLBACK_PRIORITY],
             PackageEvents::POST_PACKAGE_INSTALL =>
                 ['onPostPackageInstall', self::CALLBACK_PRIORITY],
-            ScriptEvents::POST_INSTALL_CMD =>
-                ['onPostInstallOrUpdate', self::CALLBACK_PRIORITY],
             ScriptEvents::POST_UPDATE_CMD =>
                 ['onPostInstallOrUpdate', self::CALLBACK_PRIORITY],
             ScriptEvents::PRE_AUTOLOAD_DUMP =>

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -90,7 +90,6 @@ class MergePluginTest extends TestCase
         $this->assertArrayHasKey(ScriptEvents::PRE_UPDATE_CMD, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_AUTOLOAD_DUMP, $subscriptions);
         $this->assertArrayHasKey(PackageEvents::POST_PACKAGE_INSTALL, $subscriptions);
-        $this->assertArrayHasKey(ScriptEvents::POST_INSTALL_CMD, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::POST_UPDATE_CMD, $subscriptions);
     }
 

--- a/tests/phpunit/MergePluginTest.php
+++ b/tests/phpunit/MergePluginTest.php
@@ -83,7 +83,7 @@ class MergePluginTest extends TestCase
     {
         $subscriptions = MergePlugin::getSubscribedEvents();
 
-        $this->assertCount(7, $subscriptions);
+        $this->assertCount(6, $subscriptions);
 
         $this->assertArrayHasKey(PluginEvents::INIT, $subscriptions);
         $this->assertArrayHasKey(ScriptEvents::PRE_INSTALL_CMD, $subscriptions);


### PR DESCRIPTION
This would be my take for:

- https://github.com/wikimedia/composer-merge-plugin/issues/252
- https://github.com/wikimedia/composer-merge-plugin/issues/202
- https://github.com/wikimedia/composer-merge-plugin/issues/170
- https://github.com/wikimedia/composer-merge-plugin/issues/218

Alternative for:
- https://github.com/wikimedia/composer-merge-plugin/compare/master...pikanji:composer-merge-plugin:option-to-prevent-automatic-update?expand=1
- https://github.com/wikimedia/composer-merge-plugin/pull/249

Actually the callback `onPostInstallOrUpdate` should also be renamed into something more descriptive, but anyways.

As stated in https://github.com/wikimedia/composer-merge-plugin/issues/252#issuecomment-1378669751 there's no need to run an update or any special processing when using `install`.

I've tested this in several use-cases: first install, regular install with and without `.lock` file. And it looks good to me so far.
Especially the edge-case `install` without `.lock` file is handled correctly -> it is treated as `update`.

