### PR TITLE
adding exclude feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ in the top-level composer.json file:
   (optional, see [merge-scripts](#merge-scripts) below)
 
 
+### exclude
+The `exclude` setting can stop a single or multiple files from being used in the [include](#include) setting. Similar to `include`, this setting takes a pattern that follows `glob` rules.
+
 ### require
 
 The `require` setting is identical to [`include`](#include) except when

--- a/src/PluginState.php
+++ b/src/PluginState.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Composer Merge plugin.
  *
@@ -34,6 +35,11 @@ class PluginState
      * @var array $includes
      */
     protected $includes = [];
+
+    /**
+     * @var array $includes
+     */
+    protected $excludes = [];
 
     /**
      * @var array $requires
@@ -160,6 +166,7 @@ class PluginState
         $config = array_merge(
             [
                 'include' => [],
+                'exclude' => [],
                 'require' => [],
                 'recurse' => true,
                 'replace' => false,
@@ -175,6 +182,8 @@ class PluginState
 
         $this->includes = (is_array($config['include'])) ?
             $config['include'] : [$config['include']];
+        $this->excludes = (is_array($config['exclude'])) ?
+            $config['exclude'] : [$config['exclude']];
         $this->requires = (is_array($config['require'])) ?
             $config['require'] : [$config['require']];
         $this->recurse = (bool)$config['recurse'];
@@ -195,6 +204,16 @@ class PluginState
     public function getIncludes()
     {
         return $this->includes;
+    }
+
+    /**
+     * Get list of filenames and/or glob patterns to excludes
+     *
+     * @return array
+     */
+    public function getExcludes()
+    {
+        return $this->excludes;
     }
 
     /**


### PR DESCRIPTION
## Description

While using the available `includes` features some limitations were found when trying to exclude patterns (due to `glob`). For example when using `!` on a character group, each letter is ignored instead of the group:
```
"include": [
        "sub-projects/![FooProject]*/composer.json",
],
```
This will exclude `sub-project/F*`, `sub-project/o*`, `sub-project/o*`, `sub-project/P*`, etc from being processed. This issue also causes significant toil when excluding multiple paths. 

Note: Different variations of using `!` has been considered but non has work so far

## What’s The Change ?
To get around this and not change how `includes` works, `excludes`  removed patterns and/or files from being processed.
```
"include": [
        "sub-projects/*/composer.json"
],
"exclude": [
        "sub-projects/Foo*/composer.json"
],
```
